### PR TITLE
ci: add Docker build and ghcr push workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,65 @@
+name: publish
+
+on:
+  push:
+    branches:
+      - '**'
+    tags-ignore:
+      - '**'
+
+env:
+  TAG_NAME: shepherd:${{ github.sha }}
+  BUILD_VERSION: ${{ github.sha }}
+  GITHUB_IMAGE_REPO: ghcr.io/${{ github.repository_owner }}/shepherd
+  GITHUB_IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/shepherd:${{ github.sha }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+      packages: write
+
+    steps:
+      - name: checkout
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+      - name: Set up Docker buildx
+        uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Get the tag or commit id
+        id: version
+        run: |
+          if [[ $GITHUB_REF == refs/tags/* ]]; then
+            TAG_OR_COMMIT=$(echo $GITHUB_REF | sed 's/refs\/tags\///')
+            echo "This is a tag: $TAG_OR_COMMIT"
+          else
+            TAG_OR_COMMIT=$(echo $GITHUB_SHA)
+            echo "This is a commit SHA: $TAG_OR_COMMIT"
+          fi
+          echo "TAG_OR_COMMIT=$TAG_OR_COMMIT" >> $GITHUB_OUTPUT
+        shell: bash
+
+      - name: Build and push
+        uses: docker/build-push-action@4a13e500e55cf31b7a5d59a38ab2040ab0f42f56 # v5.1.0
+        with:
+          context: .
+          push: true
+          tags: ${{ env.GITHUB_IMAGE_NAME }}
+          build-args: |
+            BUILD_VERSION=${{ steps.version.outputs.TAG_OR_COMMIT }}
+          cache-from: |
+            type=gha
+            type=registry,ref=${{ env.GITHUB_IMAGE_REPO }}:buildcache
+          cache-to: |
+            type=gha,mode=max
+            type=registry,ref=${{ env.GITHUB_IMAGE_REPO }}:buildcache,mode=max
+          platforms: linux/amd64


### PR DESCRIPTION
## Summary
- Add `.github/workflows/publish.yml` to build the Docker image and push it to `ghcr.io/<owner>/shepherd:<sha>` on every branch push (tags excluded).
- Mirrors the structure of secmon-lab/warren's publish workflow: buildx + GHA cache + registry buildcache, `BUILD_VERSION` build-arg wired to the existing `ARG BUILD_VERSION` in `Dockerfile`.

## Test plan
- [x] Workflow triggers on push to this branch
- [ ] Confirm image appears under GitHub Packages
- [ ] Verify subsequent builds hit the buildcache