### PR TITLE
refactor: rename [triage] require_review to [triage] auto

### DIFF
--- a/docs/slack.md
+++ b/docs/slack.md
@@ -108,11 +108,11 @@ This endpoint is signed with the same signing secret as `/hooks/slack/event` and
 
 **Permission model.** All three review buttons and both modals are open to any user in the channel — there is no reporter-only restriction. Idempotency falls out of the `Triaged` flag: once a triage is finalised, subsequent button clicks no-op with an ephemeral notice.
 
-**Configuration.** Whether the planner pauses for review (vs. finalising immediately) is controlled per workspace by `[triage] require_review` in the workspace TOML config. The default is `true`. Set to `false` to keep the legacy behaviour where `PlanComplete` finalises the ticket immediately.
+**Configuration.** Whether the planner pauses for review (vs. finalising immediately) is controlled per workspace by `[triage] auto` in the workspace TOML config. The default is `false` (review required). Set to `true` to opt into the legacy behaviour where `PlanComplete` finalises the ticket immediately with no human review step.
 
 ```toml
 [triage]
-require_review = true   # default; set to false to skip the review step
+auto = false   # default; set to true to skip the review step and auto-finalise
 ```
 
 **State model.** The review flow does not introduce a `PendingTriage` field on the ticket. The "current proposal" is the latest assistant `PlanComplete` in the planner's gollem history; the "review pending" state is `Triaged == false` while that latest plan is a `PlanComplete`. Edit submissions feed the edited values directly into `FinalizeTriage` — there is no intermediate "edited but unsubmitted" snapshot to reconcile.

--- a/examples/config.toml
+++ b/examples/config.toml
@@ -7,11 +7,12 @@ default_status = "open"
 closed_statuses = ["resolved", "closed"]
 
 [triage]
-# When true (default), the planner's PlanComplete proposal is parked behind
+# When false (default), the planner's PlanComplete proposal is parked behind
 # Edit / Submit / Re-investigate buttons in Slack and the ticket is only
-# finalised after a human submits. Set to false to keep the legacy fast path
-# that finalises immediately when the planner converges.
-require_review = true
+# finalised after a human submits. Set to true to opt into the legacy fast
+# path that finalises immediately when the planner converges (no human
+# review).
+auto = false
 
 [slack]
 channel = "C0123456789"

--- a/pkg/cli/config/config.go
+++ b/pkg/cli/config/config.go
@@ -51,11 +51,11 @@ type TicketSection struct {
 // TriageSection holds knobs that govern the triage flow itself, distinct from
 // the ticket schema controlled by [ticket].
 type TriageSection struct {
-	// RequireReview gates whether a PlanComplete must be confirmed by a human
-	// before it finalises the ticket. nil means the key was not specified in
-	// TOML — Validate normalises that to true (the safe default), so opting
-	// back into the legacy fast path requires an explicit `false`.
-	RequireReview *bool `toml:"require_review"`
+	// Auto, when true, finalises the ticket as soon as the planner converges
+	// — no human review step. Default (false / unset) parks the proposal
+	// behind the Edit / Submit / Re-investigate buttons in Slack and waits
+	// for someone to confirm.
+	Auto bool `toml:"auto"`
 }
 
 type SlackSection struct {
@@ -101,11 +101,11 @@ type AppConfig struct {
 }
 
 type WorkspaceConfig struct {
-	ID                  string
-	Name                string
-	SlackChannel        string
-	FieldSchema         *domainConfig.FieldSchema
-	RequireTriageReview bool
+	ID           string
+	Name         string
+	SlackChannel string
+	FieldSchema  *domainConfig.FieldSchema
+	AutoTriage   bool
 }
 
 func (a *AppConfig) Validate() error {
@@ -124,14 +124,10 @@ func (a *AppConfig) Validate() error {
 			goerr.V(WorkspaceIDKey, wsID))
 	}
 
-	// Default [triage] require_review to true when omitted. The TOML bool
-	// zero-value would otherwise silently flip every workspace into the
-	// legacy fast path, so we materialise the default here instead of relying
-	// on the zero-value.
-	if a.Triage.RequireReview == nil {
-		t := true
-		a.Triage.RequireReview = &t
-	}
+	// [triage] auto defaults to false (zero value), which means a human review
+	// step is required before the planner-proposed Complete is finalised.
+	// Workspaces that want the legacy "finalise immediately when planner
+	// converges" behaviour set auto = true explicitly.
 
 	return nil
 }
@@ -292,11 +288,11 @@ func loadSingleWorkspaceConfig(path string) (*WorkspaceConfig, error) {
 	}
 
 	return &WorkspaceConfig{
-		ID:                  appCfg.Workspace.ID,
-		Name:                wsName,
-		SlackChannel:        appCfg.Slack.Channel,
-		FieldSchema:         schema,
-		RequireTriageReview: *appCfg.Triage.RequireReview,
+		ID:           appCfg.Workspace.ID,
+		Name:         wsName,
+		SlackChannel: appCfg.Slack.Channel,
+		FieldSchema:  schema,
+		AutoTriage:   appCfg.Triage.Auto,
 	}, nil
 }
 
@@ -332,7 +328,7 @@ func BuildRegistry(ctx context.Context, configs []*WorkspaceConfig, resolve Chan
 			},
 			FieldSchema:         wc.FieldSchema,
 			SlackChannelID:      types.SlackChannelID(channelID),
-			RequireTriageReview: wc.RequireTriageReview,
+			AutoTriage:          wc.AutoTriage,
 		})
 		logger.Info("Registered workspace", "id", wc.ID, "name", wc.Name, "channel", channelID)
 	}

--- a/pkg/cli/config/config_test.go
+++ b/pkg/cli/config/config_test.go
@@ -269,32 +269,32 @@ func TestBuildRegistry(t *testing.T) {
 	gt.S(t, string(entry.SlackChannelID)).Equal("C0123456789")
 }
 
-func TestLoadWorkspaceConfigs_TriageRequireReview_DefaultsTrue(t *testing.T) {
+func TestLoadWorkspaceConfigs_TriageAuto_DefaultsFalse(t *testing.T) {
 	dir := t.TempDir()
 	path := writeToml(t, dir, "ws.toml", validTOML)
 	configs := gt.R1(config.LoadWorkspaceConfigs([]string{path})).NoError(t)
-	gt.B(t, configs[0].RequireTriageReview).True()
+	gt.B(t, configs[0].AutoTriage).False()
 }
 
-func TestLoadWorkspaceConfigs_TriageRequireReview_ExplicitFalse(t *testing.T) {
+func TestLoadWorkspaceConfigs_TriageAuto_ExplicitTrue(t *testing.T) {
 	dir := t.TempDir()
-	tomlBody := validTOML + "\n[triage]\nrequire_review = false\n"
+	tomlBody := validTOML + "\n[triage]\nauto = true\n"
 	path := writeToml(t, dir, "ws.toml", tomlBody)
 	configs := gt.R1(config.LoadWorkspaceConfigs([]string{path})).NoError(t)
-	gt.B(t, configs[0].RequireTriageReview).False()
+	gt.B(t, configs[0].AutoTriage).True()
 }
 
-func TestLoadWorkspaceConfigs_TriageRequireReview_ExplicitTrue(t *testing.T) {
+func TestLoadWorkspaceConfigs_TriageAuto_ExplicitFalse(t *testing.T) {
 	dir := t.TempDir()
-	tomlBody := validTOML + "\n[triage]\nrequire_review = true\n"
+	tomlBody := validTOML + "\n[triage]\nauto = false\n"
 	path := writeToml(t, dir, "ws.toml", tomlBody)
 	configs := gt.R1(config.LoadWorkspaceConfigs([]string{path})).NoError(t)
-	gt.B(t, configs[0].RequireTriageReview).True()
+	gt.B(t, configs[0].AutoTriage).False()
 }
 
-func TestBuildRegistry_PropagatesRequireTriageReview(t *testing.T) {
+func TestBuildRegistry_PropagatesAutoTriage(t *testing.T) {
 	dir := t.TempDir()
-	tomlBody := validTOML + "\n[triage]\nrequire_review = false\n"
+	tomlBody := validTOML + "\n[triage]\nauto = true\n"
 	writeToml(t, dir, "ws.toml", tomlBody)
 
 	configs := gt.R1(config.LoadWorkspaceConfigs([]string{dir})).NoError(t)
@@ -302,5 +302,5 @@ func TestBuildRegistry_PropagatesRequireTriageReview(t *testing.T) {
 	registry := gt.R1(config.BuildRegistry(ctx, configs, nil)).NoError(t)
 	entry, ok := registry.Get(types.WorkspaceID("test-ws"))
 	gt.B(t, ok).True()
-	gt.B(t, entry.RequireTriageReview).False()
+	gt.B(t, entry.AutoTriage).True()
 }

--- a/pkg/domain/model/workspace.go
+++ b/pkg/domain/model/workspace.go
@@ -14,7 +14,7 @@ type WorkspaceEntry struct {
 	Workspace           Workspace
 	FieldSchema         *config.FieldSchema
 	SlackChannelID      types.SlackChannelID
-	RequireTriageReview bool
+	AutoTriage          bool
 }
 
 type WorkspaceRegistry struct {

--- a/pkg/usecase/triage/complete.go
+++ b/pkg/usecase/triage/complete.go
@@ -63,7 +63,7 @@ func (e *PlanExecutor) finalizeComplete(ctx context.Context, ticket *model.Ticke
 
 // finalizeCompleteAndAnnounce is the legacy fast-path entry: persist + post
 // the BuildCompleteBlocks hand-off message. Used when the workspace has
-// require_review = false (planner converges → finalize immediately).
+// auto = true (planner converges → finalize immediately, no human review).
 func (e *PlanExecutor) finalizeCompleteAndAnnounce(ctx context.Context, ticket *model.Ticket, comp *model.Complete) error {
 	if err := e.finalizeComplete(ctx, ticket, comp); err != nil {
 		return err

--- a/pkg/usecase/triage/executor.go
+++ b/pkg/usecase/triage/executor.go
@@ -44,11 +44,12 @@ type PlanExecutor struct {
 
 // WorkspaceLookup exposes the per-workspace triage knobs the executor needs
 // at runtime. Implemented by *RegistryWorkspaceLookup in production; tests
-// pass a stub or nil. When nil, the executor takes the legacy fast path
-// (immediate finalize) on PlanComplete, which is the safe default for tests
-// that pre-date the review flow.
+// pass a stub or nil. When nil (or when the workspace is unknown), the
+// executor parks PlanComplete on the reporter-review buttons — that is the
+// safe default; opting into immediate finalisation requires an explicit
+// `[triage] auto = true` in the workspace config.
 type WorkspaceLookup interface {
-	RequireTriageReview(ws types.WorkspaceID) bool
+	AutoTriage(ws types.WorkspaceID) bool
 }
 
 // RegistryWorkspaceLookup adapts *model.WorkspaceRegistry to WorkspaceLookup.
@@ -57,9 +58,9 @@ type RegistryWorkspaceLookup struct {
 	Registry *model.WorkspaceRegistry
 }
 
-// RequireTriageReview returns the workspace's RequireTriageReview flag, or
-// false when the workspace is unknown (the safe legacy default).
-func (r *RegistryWorkspaceLookup) RequireTriageReview(ws types.WorkspaceID) bool {
+// AutoTriage returns the workspace's AutoTriage flag, or false when the
+// workspace is unknown (the safe default — review required).
+func (r *RegistryWorkspaceLookup) AutoTriage(ws types.WorkspaceID) bool {
 	if r == nil || r.Registry == nil {
 		return false
 	}
@@ -67,7 +68,7 @@ func (r *RegistryWorkspaceLookup) RequireTriageReview(ws types.WorkspaceID) bool
 	if !ok {
 		return false
 	}
-	return entry.RequireTriageReview
+	return entry.AutoTriage
 }
 
 // SlackTriageClient is the slim Slack surface the triage usecase actually
@@ -190,7 +191,10 @@ func (e *PlanExecutor) run(ctx context.Context, workspaceID types.WorkspaceID, t
 			if plan.Complete == nil {
 				return goerr.New("plan kind complete without payload")
 			}
-			if e.lookup != nil && e.lookup.RequireTriageReview(workspaceID) {
+			// Default (lookup nil, workspace unknown, or auto=false) parks on
+			// the reporter-review buttons. Only when the workspace explicitly
+			// opts into auto = true do we take the immediate-finalise path.
+			if e.lookup == nil || !e.lookup.AutoTriage(workspaceID) {
 				if err := e.enterReview(ctx, ticket, plan.Complete); err != nil {
 					return goerr.Wrap(err, "enter review")
 				}

--- a/pkg/usecase/triage/executor_test.go
+++ b/pkg/usecase/triage/executor_test.go
@@ -118,7 +118,12 @@ func TestExecutorRun_LLMProposesComplete_FinalizesTriage(t *testing.T) {
 		},
 	}
 
-	_, exec, repo, _, slack := newRig(t, llm)
+	// auto = true opts the workspace into the legacy fast-path: PlanComplete
+	// finalises immediately and posts the hand-off, no reporter review.
+	_, _, repo, hist, slack := newRig(t, llm)
+	exec := triage.NewPlanExecutor(repo, hist, llm, slack, nil, nil,
+		&fakeWorkspaceLookup{auto: map[types.WorkspaceID]bool{tWS: true}},
+		triage.Config{IterationCap: 5})
 	ticket := mustCreateTicket(t, repo, false)
 
 	gt.NoError(t, exec.RunForTest(context.Background(), tWS, ticket.ID))
@@ -218,21 +223,21 @@ func (e *simpleErr) Error() string { return e.msg }
 
 // fakeWorkspaceLookup provides a minimal triage.WorkspaceLookup for tests.
 type fakeWorkspaceLookup struct {
-	require map[types.WorkspaceID]bool
+	auto map[types.WorkspaceID]bool
 }
 
-func (f *fakeWorkspaceLookup) RequireTriageReview(ws types.WorkspaceID) bool {
+func (f *fakeWorkspaceLookup) AutoTriage(ws types.WorkspaceID) bool {
 	if f == nil {
 		return false
 	}
-	return f.require[ws]
+	return f.auto[ws]
 }
 
-// TestExecutorRun_LLMProposesComplete_RequireReview_PostsReviewWithoutFinalize
-// covers the new review-gated PlanComplete path: when the workspace has
-// RequireTriageReview=true, the executor must NOT mark Triaged=true and must
+// TestExecutorRun_LLMProposesComplete_DefaultRequiresReview_PostsReviewWithoutFinalize
+// covers the default PlanComplete path: when the workspace does not opt into
+// `[triage] auto = true`, the executor must NOT mark Triaged=true and must
 // post the review message (with the 3 buttons) instead of the legacy hand-off.
-func TestExecutorRun_LLMProposesComplete_RequireReview_PostsReviewWithoutFinalize(t *testing.T) {
+func TestExecutorRun_LLMProposesComplete_DefaultRequiresReview_PostsReviewWithoutFinalize(t *testing.T) {
 	session := newPlanSessionMock(t, []string{completePlanJSON})
 	llm := &mock.LLMClientMock{
 		NewSessionFunc: func(_ context.Context, _ ...gollem.SessionOption) (gollem.Session, error) {
@@ -240,12 +245,12 @@ func TestExecutorRun_LLMProposesComplete_RequireReview_PostsReviewWithoutFinaliz
 		},
 	}
 
-	// Build a rig but swap in a non-nil WorkspaceLookup so PlanComplete enters
-	// the review path.
+	// Build a rig with a lookup that leaves AutoTriage=false (default), so
+	// PlanComplete parks on the review buttons.
 	uc, _, repo, hist, slack := newRig(t, llm)
 	_ = uc
 	exec := triage.NewPlanExecutor(repo, hist, llm, slack, nil, nil,
-		&fakeWorkspaceLookup{require: map[types.WorkspaceID]bool{tWS: true}},
+		&fakeWorkspaceLookup{auto: map[types.WorkspaceID]bool{}},
 		triage.Config{IterationCap: 5})
 
 	ticket := mustCreateTicket(t, repo, false)

--- a/pkg/usecase/triage/usecase_test.go
+++ b/pkg/usecase/triage/usecase_test.go
@@ -474,7 +474,12 @@ func TestLifecycle_TicketCreate_Ask_Submit_Complete(t *testing.T) {
 	triageSlack := &fakeTriageSlack{}
 	catalog := tool.NewCatalog(nil, repo.ToolSettings())
 	promptUC := prompt.New(repo.Prompt())
-	exec := triage.NewPlanExecutor(repo, hist, llm, triageSlack, catalog, promptUC, nil, triage.Config{IterationCap: 5})
+	// Lifecycle test asserts the planner converges to Triaged=true; opt the
+	// workspace into auto-finalise so we exercise the legacy fast path
+	// without the reporter-review hop.
+	exec := triage.NewPlanExecutor(repo, hist, llm, triageSlack, catalog, promptUC,
+		&fakeWorkspaceLookup{auto: map[types.WorkspaceID]bool{wsID: true}},
+		triage.Config{IterationCap: 5})
 	triageUC := triage.NewUseCase(exec, &fakeResolver{ws: wsID, channel: channel})
 
 	slackUC := usecase.NewSlackUseCase(repo, registry, userSlack, "https://shepherd.example.com", llm, hist, nil)

--- a/pkg/utils/i18n/keys.go
+++ b/pkg/utils/i18n/keys.go
@@ -46,7 +46,8 @@ const (
 	MsgTriageFailedRetryButton MsgKey = "triage_failed_retry_button"
 	MsgTriageRetryQueued       MsgKey = "triage_retry_queued"
 
-	// Triage reporter-review flow (gated by [triage] require_review). The
+	// Triage reporter-review flow (default; opt out per workspace via
+	// [triage] auto = true to fall back to immediate finalisation). The
 	// review message carries Edit / Submit / Re-investigate buttons; outcomes
 	// are posted as additional thread messages instead of rewriting the
 	// review message itself.


### PR DESCRIPTION
## Summary

- Rename the workspace-level triage review knob from `[triage] require_review` to `[triage] auto`, flipping the polarity so the bool's zero value (`false`) maps to the safe default (reporter review required).
- Drops the `*bool` indirection the old default-true semantics needed; the `WorkspaceLookup` interface method becomes `AutoTriage(ws)` and the executor's `PlanComplete` branch is inverted accordingly (lookup nil / unknown workspace / auto=false → review path; only explicit `auto = true` takes the legacy fast-path).
- Updates `WorkspaceConfig.AutoTriage`, `model.WorkspaceEntry.AutoTriage`, the example TOML, `docs/slack.md`, and the i18n key comment to match the new name + semantics.
- Tests renamed + the lifecycle test now opts into `auto = true` so it still exercises the legacy convergence path; new unit tests cover default-false / explicit-true / explicit-false.

## Test plan

- [x] `task test`