### PR TITLE
feat: support multiple assignees per ticket

### DIFF
--- a/docs/slack.md
+++ b/docs/slack.md
@@ -96,14 +96,14 @@ This endpoint is signed with the same signing secret as `/hooks/slack/event` and
 | `triage_submit_answers` | Reporter clicked Submit on the triage question form. Bot reads `state.values` (keyed by `block_id == question.id`), records the answers in agent history, and resumes the planner loop. |
 | `triage_retry` | Reporter clicked the retry button on a failure-recovery message. Bot re-dispatches the planner loop for the ticket. |
 | `triage_review_edit` | Anyone clicked **Edit** on the triage review message. Bot opens the Edit modal synchronously via `views.open` (Slack's `trigger_id` is only valid for ~3 seconds). |
-| `triage_review_submit` | Anyone clicked **Submit** on the triage review message. Bot finalises the planner's latest `PlanComplete` proposal as-is, posts a follow-up "Submitted" message into the thread mentioning the assignee. The original review message is not rewritten. |
+| `triage_review_submit` | Anyone clicked **Submit** on the triage review message. Bot finalises the planner's latest `PlanComplete` proposal as-is, posts a follow-up "Submitted" message into the thread mentioning every selected assignee. The original review message is not rewritten. |
 | `triage_review_reinvestigate` | Anyone clicked **Re-investigate** on the triage review message. Bot opens the instruction modal synchronously via `views.open`. |
 
 ### `view_submission`
 
 | callback_id | Purpose |
 |-------------|---------|
-| `triage_review_edit_modal` | Edit modal submitted. Bot parses summary / assignee / custom-field inputs, persists field values to the ticket, finalises with the edited proposal, and posts the "Submitted" follow-up. Required-field violations come back as `response_action: errors` so the modal stays open. |
+| `triage_review_edit_modal` | Edit modal submitted. Bot parses summary / assignees (multi-user select) / custom-field inputs, persists field values to the ticket, finalises with the edited proposal, and posts the "Submitted" follow-up. Required-field violations come back as `response_action: errors` so the modal stays open. |
 | `triage_review_reinvestigate_modal` | Re-investigate modal submitted. Bot appends the user's instruction to the planner's gollem history as a user-role message, posts a "Re-investigating…" follow-up message into the thread, and re-dispatches the planner. The review message itself is left untouched. |
 
 **Permission model.** All three review buttons and both modals are open to any user in the channel — there is no reporter-only restriction. Idempotency falls out of the `Triaged` flag: once a triage is finalised, subsequent button clicks no-op with an ephemeral notice.

--- a/frontend/e2e/tests/ticket-detail-assignee.spec.ts
+++ b/frontend/e2e/tests/ticket-detail-assignee.spec.ts
@@ -5,6 +5,15 @@ const FAKE_USERS = [
   { id: "U_BOB", name: "Bob", email: "bob@example.com" },
 ];
 
+async function clickRemoveAssignee(page: Page, name: string) {
+  const chip = page
+    .locator("span")
+    .filter({ hasText: new RegExp(`^${name}$`) })
+    .first()
+    .locator("..");
+  await chip.getByRole("button", { name: "Remove" }).click();
+}
+
 async function stubSlackUsers(page: Page) {
   await page.route("**/api/v1/ws/*/slack/users", async (route) => {
     await route.fulfill({
@@ -137,20 +146,13 @@ test.describe("Ticket Assignee inline edit (multi-user)", () => {
     await page.goto(`/ws/support/tickets/${ticket.id}`);
     await expect(page.getByText("Remove One Test")).toBeVisible();
 
-    // Click the Remove button next to Alice's chip. The picker renders one
-    // Remove button per chip; we target the one whose neighbour is Alice.
-    const aliceChip = page
-      .locator("span")
-      .filter({ hasText: /^Alice$/ })
-      .first()
-      .locator("..");
-    const removeAlice = aliceChip.getByRole("button", { name: "Remove" });
+    // Click the Remove button next to Alice's chip.
     const patchReq = page.waitForRequest(
       (req) =>
         req.method() === "PATCH" &&
         req.url().includes(`/api/v1/ws/support/tickets/${ticket.id}`),
     );
-    await removeAlice.click();
+    await clickRemoveAssignee(page, "Alice");
     const req = await patchReq;
     expect(JSON.parse(req.postData() ?? "{}")).toEqual({
       assigneeIds: ["U_BOB"],
@@ -177,18 +179,12 @@ test.describe("Ticket Assignee inline edit (multi-user)", () => {
     await page.goto(`/ws/support/tickets/${ticket.id}`);
     await expect(page.getByText("Unassign Test")).toBeVisible();
 
-    const aliceChip = page
-      .locator("span")
-      .filter({ hasText: /^Alice$/ })
-      .first()
-      .locator("..");
-    const removeAlice = aliceChip.getByRole("button", { name: "Remove" });
     const patchReq = page.waitForRequest(
       (req) =>
         req.method() === "PATCH" &&
         req.url().includes(`/api/v1/ws/support/tickets/${ticket.id}`),
     );
-    await removeAlice.click();
+    await clickRemoveAssignee(page, "Alice");
     const req = await patchReq;
     expect(JSON.parse(req.postData() ?? "{}")).toEqual({ assigneeIds: [] });
 

--- a/frontend/e2e/tests/ticket-detail-assignee.spec.ts
+++ b/frontend/e2e/tests/ticket-detail-assignee.spec.ts
@@ -29,14 +29,14 @@ async function stubSlackUsers(page: Page) {
   });
 }
 
-test.describe("Ticket Assignee inline edit", () => {
+test.describe("Ticket Assignee inline edit (multi-user)", () => {
   test.beforeEach(async ({ page }) => {
     await page.goto("/api/auth/login");
     await page.waitForURL("/");
     await stubSlackUsers(page);
   });
 
-  test("assignee can be changed without entering Edit mode", async ({
+  test("a single assignee can be added without entering Edit mode", async ({
     page,
     request,
   }) => {
@@ -53,10 +53,10 @@ test.describe("Ticket Assignee inline edit", () => {
     const editBtn = page.getByRole("button", { name: /^Edit$/ });
     await expect(editBtn).toBeVisible();
 
-    // Open assignee picker (no Edit mode).
-    const picker = page.getByRole("button", { name: /Unassigned/i });
-    await expect(picker.first()).toBeVisible();
-    await picker.first().click();
+    // Open assignee picker by focusing its empty input.
+    const picker = page.getByPlaceholder("Unassigned");
+    await expect(picker).toBeVisible();
+    await picker.click();
 
     // Capture the PATCH request issued by selecting a user.
     const patchReq = page.waitForRequest(
@@ -67,65 +67,44 @@ test.describe("Ticket Assignee inline edit", () => {
     await page.getByRole("option", { name: "Alice" }).click();
     const req = await patchReq;
 
-    // Body must contain ONLY assigneeId — nothing else.
+    // Body must contain ONLY assigneeIds — nothing else.
     const body = JSON.parse(req.postData() ?? "{}");
-    expect(body).toEqual({ assigneeId: "U_ALICE" });
+    expect(body).toEqual({ assigneeIds: ["U_ALICE"] });
 
     // We must not have entered Edit mode.
     await expect(
       page.getByRole("button", { name: /Save changes/ }),
     ).toHaveCount(0);
 
-    // Server-side: only assignee changed.
+    // Server-side: only assignees changed.
     const after = await request
       .get(`/api/v1/ws/support/tickets/${ticket.id}`)
       .then((r) => r.json());
-    expect(after.assigneeId).toBe("U_ALICE");
+    expect(after.assigneeIds).toEqual(["U_ALICE"]);
     expect(after.title).toBe("Inline Assignee Test");
     expect(after.statusId).toBe(ticket.statusId);
     expect(after.description ?? "").toBe(ticket.description ?? "");
   });
 
-  test("inline assignee change does not touch other fields", async ({
+  test("a second assignee can be added on top of an existing one", async ({
     page,
     request,
   }) => {
     const createRes = await request.post("/api/v1/ws/support/tickets", {
-      data: {
-        title: "Field Isolation Test",
-        description: "desc-original",
-      },
+      data: { title: "Two Assignees Test" },
     });
-    expect(createRes.status()).toBe(201);
     const ticket = await createRes.json();
-
-    // Pre-populate custom fields + status via API so we have a known baseline.
-    const seedRes = await request.patch(
-      `/api/v1/ws/support/tickets/${ticket.id}`,
-      {
-        data: {
-          statusId: "in-progress",
-          fields: [
-            { fieldId: "priority", value: "high" },
-            { fieldId: "category", value: "bug" },
-            { fieldId: "reference-url", value: "https://example.com/x" },
-          ],
-        },
-      },
-    );
-    expect(seedRes.ok()).toBe(true);
-    const seeded = await seedRes.json();
+    await request.patch(`/api/v1/ws/support/tickets/${ticket.id}`, {
+      data: { assigneeIds: ["U_ALICE"] },
+    });
 
     await page.goto(`/ws/support/tickets/${ticket.id}`);
-    await expect(page.getByText("Field Isolation Test")).toBeVisible();
+    await expect(page.getByText("Two Assignees Test")).toBeVisible();
 
-    // Sanity: still not in Edit mode.
-    await expect(
-      page.getByRole("button", { name: /Save changes/ }),
-    ).toHaveCount(0);
+    // Click the picker container — clicking on the chip-area div opens the
+    // dropdown without removing the existing chip.
+    await page.getByText("Alice", { exact: true }).first().click();
 
-    // Inline-edit assignee: pick Bob.
-    await page.getByRole("button", { name: /Unassigned/i }).first().click();
     const patchReq = page.waitForRequest(
       (req) =>
         req.method() === "PATCH" &&
@@ -134,33 +113,56 @@ test.describe("Ticket Assignee inline edit", () => {
     await page.getByRole("option", { name: "Bob" }).click();
     const req = await patchReq;
     expect(JSON.parse(req.postData() ?? "{}")).toEqual({
-      assigneeId: "U_BOB",
+      assigneeIds: ["U_ALICE", "U_BOB"],
     });
 
-    // Re-fetch from server: every other field must still match the seed.
     const after = await request
       .get(`/api/v1/ws/support/tickets/${ticket.id}`)
       .then((r) => r.json());
-    expect(after.assigneeId).toBe("U_BOB");
-    expect(after.title).toBe("Field Isolation Test");
-    expect(after.description).toBe("desc-original");
-    expect(after.statusId).toBe("in-progress");
-    // Custom fields preserved.
-    const fieldMap = Object.fromEntries(
-      (after.fields ?? []).map((f: { fieldId: string; value: unknown }) => [
-        f.fieldId,
-        f.value,
-      ]),
-    );
-    const seededFieldMap = Object.fromEntries(
-      (seeded.fields ?? []).map(
-        (f: { fieldId: string; value: unknown }) => [f.fieldId, f.value],
-      ),
-    );
-    expect(fieldMap).toEqual(seededFieldMap);
+    expect(after.assigneeIds).toEqual(["U_ALICE", "U_BOB"]);
   });
 
-  test("unassign via inline picker sends only assigneeId", async ({
+  test("removing one of two assignees keeps the rest", async ({
+    page,
+    request,
+  }) => {
+    const createRes = await request.post("/api/v1/ws/support/tickets", {
+      data: { title: "Remove One Test" },
+    });
+    const ticket = await createRes.json();
+    await request.patch(`/api/v1/ws/support/tickets/${ticket.id}`, {
+      data: { assigneeIds: ["U_ALICE", "U_BOB"] },
+    });
+
+    await page.goto(`/ws/support/tickets/${ticket.id}`);
+    await expect(page.getByText("Remove One Test")).toBeVisible();
+
+    // Click the Remove button next to Alice's chip. The picker renders one
+    // Remove button per chip; we target the one whose neighbour is Alice.
+    const aliceChip = page
+      .locator("span")
+      .filter({ hasText: /^Alice$/ })
+      .first()
+      .locator("..");
+    const removeAlice = aliceChip.getByRole("button", { name: "Remove" });
+    const patchReq = page.waitForRequest(
+      (req) =>
+        req.method() === "PATCH" &&
+        req.url().includes(`/api/v1/ws/support/tickets/${ticket.id}`),
+    );
+    await removeAlice.click();
+    const req = await patchReq;
+    expect(JSON.parse(req.postData() ?? "{}")).toEqual({
+      assigneeIds: ["U_BOB"],
+    });
+
+    const after = await request
+      .get(`/api/v1/ws/support/tickets/${ticket.id}`)
+      .then((r) => r.json());
+    expect(after.assigneeIds).toEqual(["U_BOB"]);
+  });
+
+  test("removing the last assignee clears the list to empty", async ({
     page,
     request,
   }) => {
@@ -169,28 +171,31 @@ test.describe("Ticket Assignee inline edit", () => {
     });
     const ticket = await createRes.json();
     await request.patch(`/api/v1/ws/support/tickets/${ticket.id}`, {
-      data: { assigneeId: "U_ALICE" },
+      data: { assigneeIds: ["U_ALICE"] },
     });
 
     await page.goto(`/ws/support/tickets/${ticket.id}`);
     await expect(page.getByText("Unassign Test")).toBeVisible();
 
-    // Click the clear (×) button on the assignee picker.
-    const clearBtn = page.getByRole("button", { name: "Clear", exact: true });
-    await expect(clearBtn).toBeVisible();
+    const aliceChip = page
+      .locator("span")
+      .filter({ hasText: /^Alice$/ })
+      .first()
+      .locator("..");
+    const removeAlice = aliceChip.getByRole("button", { name: "Remove" });
     const patchReq = page.waitForRequest(
       (req) =>
         req.method() === "PATCH" &&
         req.url().includes(`/api/v1/ws/support/tickets/${ticket.id}`),
     );
-    await clearBtn.click();
+    await removeAlice.click();
     const req = await patchReq;
-    expect(JSON.parse(req.postData() ?? "{}")).toEqual({ assigneeId: "" });
+    expect(JSON.parse(req.postData() ?? "{}")).toEqual({ assigneeIds: [] });
 
     const after = await request
       .get(`/api/v1/ws/support/tickets/${ticket.id}`)
       .then((r) => r.json());
-    expect(after.assigneeId ?? "").toBe("");
+    expect(after.assigneeIds ?? []).toEqual([]);
     expect(after.title).toBe("Unassign Test");
   });
 
@@ -213,7 +218,7 @@ test.describe("Ticket Assignee inline edit", () => {
     await page.locator("textarea").first().fill("unsaved-desc");
 
     // Inline-edit assignee while still in Edit mode.
-    await page.getByRole("button", { name: /Unassigned/i }).first().click();
+    await page.getByPlaceholder("Unassigned").click();
     const patchReq = page.waitForRequest(
       (req) =>
         req.method() === "PATCH" &&
@@ -221,7 +226,7 @@ test.describe("Ticket Assignee inline edit", () => {
     );
     await page.getByRole("option", { name: "Alice" }).click();
     expect(JSON.parse((await patchReq).postData() ?? "{}")).toEqual({
-      assigneeId: "U_ALICE",
+      assigneeIds: ["U_ALICE"],
     });
 
     // Save changes button must still be visible — Edit mode stayed open.
@@ -236,7 +241,7 @@ test.describe("Ticket Assignee inline edit", () => {
     const after = await request
       .get(`/api/v1/ws/support/tickets/${ticket.id}`)
       .then((r) => r.json());
-    expect(after.assigneeId).toBe("U_ALICE");
+    expect(after.assigneeIds).toEqual(["U_ALICE"]);
     expect(after.title).toBe("Mid-Edit Test");
     expect(after.description).toBe("original-desc");
   });

--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -335,7 +335,7 @@ export interface components {
             title: string;
             description?: string;
             statusId: string;
-            assigneeId?: string;
+            assigneeIds: string[];
             reporterSlackUserId?: string;
             slackChannelId?: string;
             slackThreadTs?: string;
@@ -349,14 +349,14 @@ export interface components {
             title: string;
             description?: string;
             statusId?: string;
-            assigneeId?: string;
+            assigneeIds?: string[];
             fields?: components["schemas"]["FieldValue"][];
         };
         UpdateTicketRequest: {
             title?: string;
             description?: string;
             statusId?: string;
-            assigneeId?: string;
+            assigneeIds?: string[];
             fields?: components["schemas"]["FieldValue"][];
         };
         SlackUserInfo: {

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -247,6 +247,8 @@ export const en: Messages = {
   ticketDetailSaveChanges: "Save changes",
   ticketDetailLabelStatus: "Status",
   ticketDetailLabelAssignee: "Assignee",
+  ticketDetailLabelAssignees: "Assignees",
+  ticketAssigneePlusMore: "+{count} more",
   ticketDetailLabelReporter: "Reporter",
   ticketDetailLabelCreated: "Created",
   ticketDetailLabelUpdated: "Updated",

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -246,7 +246,6 @@ export const en: Messages = {
   ticketDetailSaving: "Saving…",
   ticketDetailSaveChanges: "Save changes",
   ticketDetailLabelStatus: "Status",
-  ticketDetailLabelAssignee: "Assignee",
   ticketDetailLabelAssignees: "Assignees",
   ticketAssigneePlusMore: "+{count} more",
   ticketDetailLabelReporter: "Reporter",

--- a/frontend/src/i18n/ja.ts
+++ b/frontend/src/i18n/ja.ts
@@ -247,7 +247,6 @@ export const ja: Messages = {
   ticketDetailSaving: "保存中…",
   ticketDetailSaveChanges: "変更を保存",
   ticketDetailLabelStatus: "ステータス",
-  ticketDetailLabelAssignee: "担当者",
   ticketDetailLabelAssignees: "担当者",
   ticketAssigneePlusMore: "他{count}名",
   ticketDetailLabelReporter: "起票者",

--- a/frontend/src/i18n/ja.ts
+++ b/frontend/src/i18n/ja.ts
@@ -248,6 +248,8 @@ export const ja: Messages = {
   ticketDetailSaveChanges: "変更を保存",
   ticketDetailLabelStatus: "ステータス",
   ticketDetailLabelAssignee: "担当者",
+  ticketDetailLabelAssignees: "担当者",
+  ticketAssigneePlusMore: "他{count}名",
   ticketDetailLabelReporter: "起票者",
   ticketDetailLabelCreated: "作成",
   ticketDetailLabelUpdated: "更新",

--- a/frontend/src/i18n/keys.ts
+++ b/frontend/src/i18n/keys.ts
@@ -247,6 +247,8 @@ export const msgKeys = {
   ticketDetailSaveChanges: "ticketDetailSaveChanges",
   ticketDetailLabelStatus: "ticketDetailLabelStatus",
   ticketDetailLabelAssignee: "ticketDetailLabelAssignee",
+  ticketDetailLabelAssignees: "ticketDetailLabelAssignees",
+  ticketAssigneePlusMore: "ticketAssigneePlusMore",
   ticketDetailLabelReporter: "ticketDetailLabelReporter",
   ticketDetailLabelCreated: "ticketDetailLabelCreated",
   ticketDetailLabelUpdated: "ticketDetailLabelUpdated",

--- a/frontend/src/i18n/keys.ts
+++ b/frontend/src/i18n/keys.ts
@@ -246,7 +246,6 @@ export const msgKeys = {
   ticketDetailSaving: "ticketDetailSaving",
   ticketDetailSaveChanges: "ticketDetailSaveChanges",
   ticketDetailLabelStatus: "ticketDetailLabelStatus",
-  ticketDetailLabelAssignee: "ticketDetailLabelAssignee",
   ticketDetailLabelAssignees: "ticketDetailLabelAssignees",
   ticketAssigneePlusMore: "ticketAssigneePlusMore",
   ticketDetailLabelReporter: "ticketDetailLabelReporter",

--- a/frontend/src/pages/ticket-detail.tsx
+++ b/frontend/src/pages/ticket-detail.tsx
@@ -110,7 +110,7 @@ export default function TicketDetailPage() {
       title?: string;
       description?: string;
       statusId?: string;
-      assigneeId?: string;
+      assigneeIds?: string[];
       fields?: { fieldId: string; value: unknown }[];
     }) => {
       const { data, error } = await api.PATCH(
@@ -570,8 +570,8 @@ export default function TicketDetailPage() {
               statuses={configData?.statuses ?? []}
               fields={configData?.fields ?? []}
               onChangeStatus={(statusId) => updateTicket.mutate({ statusId })}
-              onChangeAssignee={(assigneeId) =>
-                updateTicket.mutate({ assigneeId })
+              onChangeAssignees={(assigneeIds) =>
+                updateTicket.mutate({ assigneeIds })
               }
               isEditing={isEditing}
               isAssigneePending={updateTicket.isPending}
@@ -647,7 +647,7 @@ interface UnifiedSidebarProps {
   ticket: {
     id: string;
     statusId: string;
-    assigneeId?: string;
+    assigneeIds: string[];
     reporterSlackUserId?: string;
     slackChannelId?: string;
     fields?: { fieldId: string; value: unknown }[];
@@ -658,7 +658,7 @@ interface UnifiedSidebarProps {
   statuses: { id: string; name: string; color: string }[];
   fields: { id: string; name: string; type: string; required: boolean }[];
   onChangeStatus: (id: string) => void;
-  onChangeAssignee: (id: string) => void;
+  onChangeAssignees: (ids: string[]) => void;
   isEditing: boolean;
   isAssigneePending: boolean;
   renderFieldValue: (fieldId: string, value: unknown) => ReactNode;
@@ -673,7 +673,7 @@ function UnifiedSidebar({
   statuses,
   fields,
   onChangeStatus,
-  onChangeAssignee,
+  onChangeAssignees,
   isEditing,
   isAssigneePending,
   renderFieldValue,
@@ -752,12 +752,17 @@ function UnifiedSidebar({
 
         <div className="h-px bg-line my-1" />
 
-        <FieldRow label={t("ticketDetailLabelAssignee")}>
+        <FieldRow label={t("ticketDetailLabelAssignees")}>
           <UserPicker
+            multi
             users={slackUsers}
-            value={ticket.assigneeId ?? ""}
-            onChange={(v) => {
-              if (v !== (ticket.assigneeId ?? "")) onChangeAssignee(v);
+            value={ticket.assigneeIds}
+            onChange={(ids) => {
+              const before = ticket.assigneeIds;
+              const sameLength = before.length === ids.length;
+              const sameOrder =
+                sameLength && before.every((id, i) => id === ids[i]);
+              if (!sameOrder) onChangeAssignees(ids);
             }}
             disabled={isAssigneePending}
             placeholder={t("ticketDetailUnassigned")}

--- a/frontend/src/pages/ticket-detail.tsx
+++ b/frontend/src/pages/ticket-detail.tsx
@@ -758,11 +758,13 @@ function UnifiedSidebar({
             users={slackUsers}
             value={ticket.assigneeIds}
             onChange={(ids) => {
-              const before = ticket.assigneeIds;
-              const sameLength = before.length === ids.length;
-              const sameOrder =
-                sameLength && before.every((id, i) => id === ids[i]);
-              if (!sameOrder) onChangeAssignees(ids);
+              // Compare by membership rather than positional order so
+              // re-ordering alone does not trigger a redundant PATCH.
+              const before = [...ticket.assigneeIds].sort();
+              const after = [...ids].sort();
+              if (JSON.stringify(before) !== JSON.stringify(after)) {
+                onChangeAssignees(ids);
+              }
             }}
             disabled={isAssigneePending}
             placeholder={t("ticketDetailUnassigned")}

--- a/frontend/src/pages/ticket-kanban.tsx
+++ b/frontend/src/pages/ticket-kanban.tsx
@@ -23,7 +23,10 @@ const LANE_GAP = 14;
 type DragData = {
   ticketId: string;
   fromStatusId: string;
-  fromAssigneeId: string;
+  // The assignee lane the card was dragged from. Empty string means the
+  // unassigned lane. A ticket may render in multiple assignee lanes; this
+  // captures whichever one initiated the drag so self-drops are detected.
+  fromAssigneeLaneId: string;
 };
 
 function timeAgo(iso: string): string {
@@ -90,13 +93,13 @@ export function TicketKanbanView({
     mutationFn: async (vars: {
       ticketId: string;
       statusId: string;
-      assigneeId?: string;
+      assigneeIds?: string[];
       assigneeChange: boolean;
     }) => {
-      const body: { statusId?: string; assigneeId?: string } = {
+      const body: { statusId?: string; assigneeIds?: string[] } = {
         statusId: vars.statusId,
       };
-      if (vars.assigneeChange) body.assigneeId = vars.assigneeId ?? "";
+      if (vars.assigneeChange) body.assigneeIds = vars.assigneeIds ?? [];
       const { data, error } = await api.PATCH(
         "/api/v1/ws/{workspaceId}/tickets/{ticketId}",
         {
@@ -126,7 +129,7 @@ export function TicketKanbanView({
                     ...tk,
                     statusId: vars.statusId,
                     ...(vars.assigneeChange
-                      ? { assigneeId: vars.assigneeId || undefined }
+                      ? { assigneeIds: vars.assigneeIds ?? [] }
                       : {}),
                   }
                 : tk,
@@ -153,11 +156,12 @@ export function TicketKanbanView({
     const ids: string[] = [];
     const seen = new Set<string>();
     for (const tk of tickets) {
-      const id = tk.assigneeId;
-      if (!id) continue;
-      if (seen.has(id)) continue;
-      seen.add(id);
-      ids.push(id);
+      for (const id of tk.assigneeIds ?? []) {
+        if (!id) continue;
+        if (seen.has(id)) continue;
+        seen.add(id);
+        ids.push(id);
+      }
     }
     ids.sort();
     return ids;
@@ -232,14 +236,22 @@ export function TicketKanbanView({
             tickets={tickets}
             statuses={statuses}
             assignees={assignees}
-            onMove={(d, target) =>
+            onMove={(d, target) => {
+              const targetIds = target.laneAssigneeId
+                ? [target.laneAssigneeId]
+                : [];
+              const tk = tickets.find((x) => x.id === d.ticketId);
+              const before = tk?.assigneeIds ?? [];
+              const sameLength = before.length === targetIds.length;
+              const sameMembership =
+                sameLength && before.every((id, i) => id === targetIds[i]);
               move.mutate({
                 ticketId: d.ticketId,
                 statusId: target.statusId,
-                assigneeId: target.assigneeId,
-                assigneeChange: d.fromAssigneeId !== target.assigneeId,
-              })
-            }
+                assigneeIds: targetIds,
+                assigneeChange: !sameMembership,
+              });
+            }}
           />
         )}
       </div>
@@ -332,6 +344,10 @@ function BoardByStatus({
 }
 
 // ── Assignee swimlanes ──────────────────────────────
+//
+// Tickets with multiple assignees render once per lane they belong to.
+// Dropping a card onto a lane *replaces* its assignee list with that lane's
+// owner (or empties it for the Unassigned lane).
 function BoardByAssignee({
   workspaceId,
   tickets,
@@ -345,7 +361,7 @@ function BoardByAssignee({
   assignees: string[];
   onMove: (
     d: DragData,
-    target: { statusId: string; assigneeId: string },
+    target: { statusId: string; laneAssigneeId: string },
   ) => void;
 }) {
   const { t } = useTranslation();
@@ -389,7 +405,9 @@ function BoardByAssignee({
 
       {lanes.map((lane) => {
         const myCards = tickets.filter((tk) =>
-          lane.isUnassigned ? !tk.assigneeId : tk.assigneeId === lane.id,
+          lane.isUnassigned
+            ? !tk.assigneeIds || tk.assigneeIds.length === 0
+            : (tk.assigneeIds ?? []).includes(lane.id),
         );
         return (
           <div
@@ -438,12 +456,12 @@ function BoardByAssignee({
                     onDropTicket={(d) => {
                       if (
                         d.fromStatusId === s.id &&
-                        d.fromAssigneeId === lane.id
+                        d.fromAssigneeLaneId === lane.id
                       )
                         return;
                       onMove(d, {
                         statusId: s.id,
-                        assigneeId: lane.id,
+                        laneAssigneeId: lane.id,
                       });
                     }}
                   >
@@ -454,9 +472,10 @@ function BoardByAssignee({
                     ) : (
                       cards.map((tk) => (
                         <TicketCard
-                          key={tk.id}
+                          key={`${lane.id || "unassigned"}:${tk.id}`}
                           workspaceId={workspaceId}
                           ticket={tk}
+                          fromAssigneeLaneId={lane.id}
                         />
                       ))
                     )}
@@ -607,10 +626,15 @@ function TicketCard({
   workspaceId,
   ticket,
   showAssignee,
+  fromAssigneeLaneId,
 }: {
   workspaceId: string;
   ticket: Ticket;
   showAssignee?: boolean;
+  // When rendered inside an assignee lane, identifies which lane the drag
+  // originates from (empty string = Unassigned). Status-grouped boards leave
+  // this undefined; we fall back to the ticket's first assignee.
+  fromAssigneeLaneId?: string;
 }) {
   const navigate = useNavigate();
   const { t } = useTranslation();
@@ -624,7 +648,10 @@ function TicketCard({
         const data: DragData = {
           ticketId: ticket.id,
           fromStatusId: ticket.statusId,
-          fromAssigneeId: ticket.assigneeId ?? "",
+          fromAssigneeLaneId:
+            fromAssigneeLaneId !== undefined
+              ? fromAssigneeLaneId
+              : (ticket.assigneeIds ?? [])[0] ?? "",
         };
         e.dataTransfer.setData(DRAG_MIME, JSON.stringify(data));
         e.dataTransfer.effectAllowed = "move";
@@ -677,13 +704,20 @@ function TicketCard({
               <span className="w-8 shrink-0 text-[10.5px] font-medium text-ink-4 uppercase tracking-wide">
                 {t("ticketBoardAssigneePrefix")}
               </span>
-              {ticket.assigneeId ? (
-                <span className="min-w-0 truncate">
+              {ticket.assigneeIds && ticket.assigneeIds.length > 0 ? (
+                <span className="min-w-0 truncate inline-flex items-center gap-1.5">
                   <SlackUserName
                     workspaceId={workspaceId}
-                    userId={ticket.assigneeId}
+                    userId={ticket.assigneeIds[0]}
                     size="xs"
                   />
+                  {ticket.assigneeIds.length > 1 && (
+                    <span className="text-[10.5px] text-ink-3">
+                      {t("ticketAssigneePlusMore", {
+                        count: ticket.assigneeIds.length - 1,
+                      })}
+                    </span>
+                  )}
                 </span>
               ) : (
                 <span

--- a/frontend/src/pages/ticket-kanban.tsx
+++ b/frontend/src/pages/ticket-kanban.tsx
@@ -242,9 +242,13 @@ export function TicketKanbanView({
                 : [];
               const tk = tickets.find((x) => x.id === d.ticketId);
               const before = tk?.assigneeIds ?? [];
-              const sameLength = before.length === targetIds.length;
+              // Compare by membership so the lane-replace drop only fires a
+              // PATCH when the assignee set actually differs.
+              const beforeSet = new Set(before);
+              const targetSet = new Set(targetIds);
               const sameMembership =
-                sameLength && before.every((id, i) => id === targetIds[i]);
+                beforeSet.size === targetSet.size &&
+                [...beforeSet].every((id) => targetSet.has(id));
               move.mutate({
                 ticketId: d.ticketId,
                 statusId: target.statusId,

--- a/frontend/src/pages/ticket-list.tsx
+++ b/frontend/src/pages/ticket-list.tsx
@@ -545,11 +545,20 @@ export default function TicketListPage() {
                         return <Td key={id}>{renderField(id, fv?.value)}</Td>;
                       })}
                       <Td>
-                        {tk.assigneeId ? (
-                          <SlackUserName
-                            workspaceId={workspaceId!}
-                            userId={tk.assigneeId}
-                          />
+                        {tk.assigneeIds && tk.assigneeIds.length > 0 ? (
+                          <span className="inline-flex items-center gap-1.5">
+                            <SlackUserName
+                              workspaceId={workspaceId!}
+                              userId={tk.assigneeIds[0]}
+                            />
+                            {tk.assigneeIds.length > 1 && (
+                              <span className="text-[11.5px] text-ink-3">
+                                {t("ticketAssigneePlusMore", {
+                                  count: tk.assigneeIds.length - 1,
+                                })}
+                              </span>
+                            )}
+                          </span>
                         ) : (
                           <span className="text-ink-4 text-[12.5px] italic">
                             {t("ticketListUnassigned")}

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -622,8 +622,10 @@ components:
           type: string
         statusId:
           type: string
-        assigneeId:
-          type: string
+        assigneeIds:
+          type: array
+          items:
+            type: string
         reporterSlackUserId:
           type: string
         slackChannelId:
@@ -640,7 +642,7 @@ components:
         updatedAt:
           type: string
           format: date-time
-      required: [id, seqNum, title, statusId, fields, createdAt, updatedAt]
+      required: [id, seqNum, title, statusId, assigneeIds, fields, createdAt, updatedAt]
 
     CreateTicketRequest:
       type: object
@@ -651,8 +653,10 @@ components:
           type: string
         statusId:
           type: string
-        assigneeId:
-          type: string
+        assigneeIds:
+          type: array
+          items:
+            type: string
         fields:
           type: array
           items:
@@ -668,8 +672,10 @@ components:
           type: string
         statusId:
           type: string
-        assigneeId:
-          type: string
+        assigneeIds:
+          type: array
+          items:
+            type: string
         fields:
           type: array
           items:

--- a/pkg/controller/http/generated.go
+++ b/pkg/controller/http/generated.go
@@ -80,7 +80,7 @@ type CreateSourceRequestProvider string
 
 // CreateTicketRequest defines model for CreateTicketRequest.
 type CreateTicketRequest struct {
-	AssigneeId  *string       `json:"assigneeId,omitempty"`
+	AssigneeIds *[]string     `json:"assigneeIds,omitempty"`
 	Description *string       `json:"description,omitempty"`
 	Fields      *[]FieldValue `json:"fields,omitempty"`
 	StatusId    *string       `json:"statusId,omitempty"`
@@ -224,7 +224,7 @@ type StatusDef struct {
 
 // Ticket defines model for Ticket.
 type Ticket struct {
-	AssigneeId          *string      `json:"assigneeId,omitempty"`
+	AssigneeIds         []string     `json:"assigneeIds"`
 	CreatedAt           time.Time    `json:"createdAt"`
 	Description         *string      `json:"description,omitempty"`
 	Fields              []FieldValue `json:"fields"`
@@ -263,7 +263,7 @@ type UpdateSourceRequest struct {
 
 // UpdateTicketRequest defines model for UpdateTicketRequest.
 type UpdateTicketRequest struct {
-	AssigneeId  *string       `json:"assigneeId,omitempty"`
+	AssigneeIds *[]string     `json:"assigneeIds,omitempty"`
 	Description *string       `json:"description,omitempty"`
 	Fields      *[]FieldValue `json:"fields,omitempty"`
 	StatusId    *string       `json:"statusId,omitempty"`
@@ -1417,42 +1417,42 @@ var swaggerSpec = []string{
 	"eBwGAr7lREASnCqRQxjIeAsp1u+pXabHSiUI2wS3t2FwQeJL6JeqisfzpP6Xi0uZ4Rh6BV/XRsyRfVs8",
 	"NJic8TQFpgxYgmcgFAHzYMWTnef1MIgFYAXJS/POmosUq+A0SLCCI0VSCMLuKyTxSpIUx5cfJYjzxA9C",
 	"ZdTvWkbzjdCqWFfoSzk3X/0BsdKTnJmnS56LGD7Atxykx9gEZCxIpghnXk0zwa9IAkI/BJanWiHGzfAv",
-	"HntzQccNKmXa8f262wDr1R1LSTYM4NwP8phpawI0MYKIgtT88VcB6+A0+EtUJVPkQib6RQ//hGkO+mUn",
-	"DQuBd8ajCqtc9miiiKIwjosd5oPjDVNE7X7DK6Byvg9tIt5NMyOhGN/E1qewAes1rAkjhVrzdO5JHMsA",
-	"ngfciJrpzXd2fo87K+PLuVacU8C10RMmuNADvflsDHGSao97sXyX+XGMOeViDoIpKJxgZQgSJ4lxD6bv",
-	"a0ItjXbU6IG+17heUy4cegWdKPiuQ4vl6cpwggSqh4dBmlNFjsqPuTSP7bfugybfDo1UxtZytoOcSX9f",
-	"wobB96MNP3Jf6n/kwgg6f11/dkTSjAtLS7o8nQYborb5ahHzNEqPUvJnrjAjkdxCtgWRRNnlJkp4igmL",
-	"jFCD3ZVTro1joV0xwofmW8PDluC79tlxPYxkH7Y9keENWFDxCkvwQtrHGBO5vzZxWKnYXwjsyuVlrrY2",
-	"zJs2QooJnUMULW16A9VO+xqUk99OOqbc0qHBY8HFFlC5OjmSGcRkTWJU5Rna5CTBLAakox6pLSAdyWiL",
-	"JZL4CpLFZ/YmzdQOXW+BIcYRvwIhSAIIvhOpJNqBQs/0e5JyhYhEuSRsYyStsND/k/CZ2RUdSjHDG0jQ",
-	"aoeKMHy++MxmrFSIfOcU8FNhniUjayKWU4pXOmYaxFKLGyvi1W6MUhuxoHMHhHSk2HTD8RB6IQIqwQBG",
-	"sQKpkFRcQIKcuEWFDmEKNiD8JFcEQaVHA63+qFpSrrwxtSab3NWcpj0aOGsSVogClgpxBpVxTgFnZM2A",
-	"mqPiXCqekj+tK9ozrLHGZM2FCSuJ1BYrpMMpoziGLacJCIk4ozu/9GnlvDnnUmldEEmAKbImINAzWGwW",
-	"6HOgBMEb+Bw8X/gileplkHcWCmyjmfim48BHGqhnuRDAVOnAZ4OR+3xqaFqEml5pRUBYD7h6CDsM+8P3",
-	"U2VMLyt2t07W0H055F5cMYJkBUmV6ZWmlUmjSJ1xtqYk9uW8FfGpX6cwACF4Y/fl9PoaF2K7VbpliRUR",
-	"tqfzKb4st5lszefU277ykeINfBR3qdHDK8q+1c8ee3X3yqvdXrvJvg0LL94YitLGSm7+rvu62TKZgGez",
-	"hVLbkA+3FJZml/taG3LnjQiRZ5TLvi1W/0ZPOFymEKHbZVndindrU/tsvCh3y7O6DXsE3IM2KHq8IEBv",
-	"YkAsBztSelP27a2Ow5pthKl/vPBUJNesOttixoCeD3TALrYCcHIh/SP26ajsUUy83TZrbdXvKJUpvVL3",
-	"eH3W/pA6MwXXkzkmFpduhqa/u4a33JrAGudULfvBatnXfiHszO+1gHOqR3iYFl9hQotVpW9laOZ7w/SQ",
-	"nmSHoYcFOZ33BTCWNn/KXax74WvOKt1qlPc1IdLOFwYbrODrivL4ssEGI41LA1tddsvIyiIflh9NrNyp",
-	"L9vx6XA3zs74f9BN7VheHiZ07Z3XYZy1KCln7Uv5fcCqdVM9iNGyNzwkqNFHLnGG6ZpUCwCPDqpFc0OC",
-	"GpTYRrdUqyWzRr7O3i76WhZxi1cXKcHS9T7Qy/fntc3OaXC8OFkc2/YxMJyR4DT4aXG8+EmvibDaGjgi",
-	"nJHo6iTaAqZ2c7mxywPtUKz9oeM0+BeoX+0IbYvMOHO4/v34uLU7wllGSWxejf5w5FWdWjUjxUIxHpBu",
-	"nB+P5qbz3b/1t7dhadm17LXqNyJVGc3ysKZdV3Knhl+Vzp3wa+FRE74nJtFNbZF8O+T3Squwce76u9+Y",
-	"akhUP+u8/XJHdCcC5zc+DF4cv+g2KN5yhX7hOUtG4IniMutHUSqT+bFjVbLTvSBmW7TDqffejfmhWDWz",
-	"tqb2pJSt9TzHcrYQfZCELfCNborbDYM5bNW8G9Dh6PDyHsa9BnDj8GJe9H5kl4xfM1TeCDGvZ7kHtCW+",
-	"gh+Cmlm/vnKXNPaM4qFeZW+39mJbtdrtaaU5RYgxpSAQkehaEEXYZoH+k0uF4FuOKXJNt7+doGdcoJPB",
-	"/u4/EVdbENdEAnpx/DMqOoeLIAxSwkiqNzgnoz3g7smEP6OaN2du7z0ii8ajJyR1MCUzolIP/Pl+1Cvb",
-	"tR413RAU18bM46BoS6TiYjeB9n91I58MJzVTzMXe3EpRBslIsSjFT60WMxhvpksFmBNEAwGXHp9+sAOe",
-	"LFsqLDZQP6bo50XFkYMDrQVPx5hrhG0ZXHcYlxuatQe4bqoEOcMQln7yncmgTYOfEI9+KADBEuE6fJPj",
-	"H3GBmuY/FbI1LeUol+7Oay+7lq3uR7WuLvWe1odpnNONcaWVfUeinLyxqfkhusnNkcLg0rtpy13Z0XNf",
-	"OC+uzU6/Knyfy/OW7+7JCaa9PJIIbswjyoKa2tPyoDwyHUyAQuz0nWXYU8rrl6oPANx+1XkIEd+t70lV",
-	"6uRwAe6c0sXWKufW78fd8H6FE1QqXZadloyp5cD6PLqxfzgSSoCCPcVq+vW1+f4QfvVzUKHEHVnISwl6",
-	"n2i8Nok1TGs73nYhqJ9LPS4IDp8lvjO4B17L9WfJIfjfnpsM8/+FG3MQX3/LwexVC2dX58sDP/bxv1te",
-	"z/C8Wx4MH7jw1PCaVHjcLZGxwlOIPeTaa7g0XRQ/1Xispal5DP3Apalw20hpOkDmRTfF798m1J1DOG28",
-	"M1D+Xm9aYbGqJVODsm95/+NtO36A8JmRvEPV94eAdV/ldY9Mf0yumpfkWoe0+PVtb8k9KwY9mXRon5tU",
-	"Rk6qk8WvbMcKZSn4oboUinM6sjzinC5BKcI2j2qPXGo+baFS3twbXasYuYc5fDWyTI/cXZgzRdB/jggG",
-	"6eru3ME3Ho1rew+y9Wjdmu+/3ti+qd97bXAKeY5sDs1//wsAAP//qkmQnyhAAAA=",
+	"HntzQccNKmXa8f262wDr1R1LSTYM4DwxH4mCVHqNcF9gIfBOfx4zek2AtmT+VcA6OA3+ElVpFrlgin7R",
+	"wz9hmoNvMqmwyuW5PxAUURTGEbPDfEC9YYqo3W94BVTO965N0btpZiQU45vY+hQ2YL2GNWGkUGuezj0p",
+	"ZbnB84AbUTO9+c7O73FnZXw514pzCrg2esIEF3qgN9ONIU5S7XEvlu8yP44xp1zMQTAFhROsDHXiJDHu",
+	"wfR9Tagl2I4aPdD3GtdryoVDryAaBd91aLE8XRm2kED18DBIc6rIUfkxl+ax/dZ90LTcIZjK2FrOdpAz",
+	"6e9L2DD4frThR+5L/Y9cGEHnr+vPjkiacWEJSxeu02BD1DZfLWKeRulRSv7MFWYkklvItiCSKLvcRAlP",
+	"MWGREWqwu3LKtXEstCtG+NB8axjaUn/XPjuuh5Hsw7YnMrwBCypeYQleSPsYY2JVqE0cVir2lwi7pnmZ",
+	"q60N86aNkGJC5xBFS5veQLXTvgbl5LeTjim3qGjwWHCxBVSuW45kBjFZkxhVeYY2OUkwiwHpqEdqC0hH",
+	"MtpiiSS+gmTxmb1JM7VD11tgiHHEr0AIkgCC70QqiXag0DP9nqRcISJRLgnbGEkrLPT/JHxmdq2HUszw",
+	"BhK02qEiDJ8vPrMZaxgi3zkF/FSYZ8nIaonllOKVjpkGsdTixop4tRuj1EYs6NwBIR0pNt1wPIReiIBK",
+	"MIBRrEAqJBUXkCAnblGhQ5iCDQg/yRVBUOnRQKs/qpaUK29MrckmdzWnaY8GzpqEFaKApUKcQWWcU8AZ",
+	"WTOg5qg4l4qn5E/rivYMa6wxWXNhwkoitcUK6XDKKI5hy2kCQiLO6M4vfVo5b865VFoXRBJgiqwJCPQM",
+	"FpsF+hwoQfAGPgfPF75IpXoZ5J2FAttoJr7pOPCRBupZLgQwVTrw2WDkPp8amhahpldaERDWA64ewg7D",
+	"/vD9VBnTy4rdTZU1dF8OuRdXjCBZQVJleqVpZdIoUmecrSmJfTlvRXzq1ykMQAje2Jc5vb7GhdhulW5Z",
+	"YkWE7el8ii/LDShb8zn1tq98pHgDH8VdavTwirJv9bPHLt698srfFth3w8KLN4aitLGSm78fv242Uybg",
+	"2Wyu1Lbqw82GpdnlvtaG3HkjQuQZ5bJvi9W/0RMOlylE6HZZVrfi3drUPhsvyt3ygfoQe4Tig7Yuevwj",
+	"QG9vQCwHu1h6u/btrY7Qmm2EqX+88NQq1+A622LGgJ4PdM0utgJwcuEHeK9eyx5lxtuhs9ZWnZBSmbAR",
+	"IaWP6v6v69AfememMHsyzMTs0s03uxm2xjlVy37oWta2Xwg783st4JzqER5GxleY0GL16VtBmvneMD2k",
+	"hxRg6GFBYud94YylzaZyt+te+JqzSrcaNX5NiLTzhcEGK/i6ojy+bLDGSOvTRkVNdsvIyiIflh9NrNyp",
+	"s9vx6XDXzs74f92P7WBSHlR0kZjXo5y1rCln7SODfcCq9WM9iNGyuzwkqNGJLnGG6ZpUSwiPDqpFgEOC",
+	"GmTZRrdUqyWzRsvO3i76WhZxy18XKcHSdU/Qy/fnte3SaXC8OFkc2wY0MJyR4DT4aXG8+EmvqrDaGjgi",
+	"nJHo6iTaAqZ2e7qxCwztUKz9oeM0+BeoX+0IbYvMOHO4/v34uLW/wllGSWxejf5wtFadiDUjxUIxHpBu",
+	"nB+P5rb13b/1t7dhadm17LXqNyJVGc3ysKZdV3Knhl+Vzp3wa+FRE74nJtFNbZl9O+T3Squwcab7u9+Y",
+	"akhUP0e9/XJHdCcC5zc+DF4cv+i2ON5yhX7hOUtG4IniMutHUSqT+bFjVbLTvSBmm7zDqffejfmhWDWz",
+	"tqb2pJStdU3HcrYQfZCELfCNboqbE4M5bNW8G9Dh6PDyjse9BnDj+GNe9H5kl4xfM1TeNjGvZ7kHtCW+",
+	"gh+CmlnZvnIXQPaM4qFuZ2+/92JbNevteac5h4gxpSAQkehaEEXYZoH+k0uF4FuOKXJtu7+doGdcoJPB",
+	"DvE/EVdbENdEAnpx/DMqeo+LIAxSwkiqtz4no13k7tmGP6Oat3Ju7z0ii9alJyR1MCUzolIP/Pl+1Csb",
+	"vh413RAU18bM46BoS6TiYjeB9n91I58MJzVTzMXe3EpRBslIsSjFT60WMxhvpksFmDNIAwGXHp9+sAOe",
+	"LFsqLDZQP+jo50XFkYMDrQVPx5hrhG0ZXHcYlxuatUfAbqoEOcMQln7yncmgTYOfEI9+KADBEuE6fJPj",
+	"H3GBmuY/FbI1recol+4+bS+7li3xR7WuLvWe1odpnPSNcaWVfUeinLyxqfkhusnN0cPg0rtpy13Z0XMX",
+	"OS+u5E6/hnyfy/OW7+7JCabxPJIIbswjyoKa2tPyoDx0HUyAQuz0nWXYU8rrF7YPANx+1XkIEd+N8klV",
+	"6uRwAe6c0sXWKufW78fd8H6FE1QqXZadloyp5cD6PLqxfzgSSoCCPd9q+vW1+f4QfvVzUKHEHVnISwl6",
+	"n2i8Nok1TGs73nYhqJ9YPS4IDp8lvtO5B17L9WfJIfjfnpsM8/+FG3MQX3/LwexVC2dXJ88DPyTyv1te",
+	"8PC8Wx4ZH7jw1PCaVHjcPZOxwlOIPeTaa7g0XRQ/9nispal5QP3Apalw20hpOkDmRTfFb+sm1J1DOG28",
+	"M1D+FnBaYbGqJVODsm95/+NtO36A8JmRvEPV94eAdV/ldY9Mf0yumpfkWoe0+GVvb8k9KwY9mXRon5tU",
+	"Rk6qk8UveMcKZSn4oboUinM6sjzinC5BKcI2j2qPXGo+baFS3ukbXasYuYc5fDWyTI/cXaUzRdB/jggG",
+	"6epW3cE3Ho0LfQ+y9Wjdu++/+Ni+6997oXAKeY5sDs1//wsAAP//XulTk4RAAAA=",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/pkg/controller/http/handler.go
+++ b/pkg/controller/http/handler.go
@@ -99,12 +99,18 @@ func (h *APIHandler) CreateTicket(w http.ResponseWriter, r *http.Request, worksp
 	}
 
 	var statusID types.StatusID
-	var assigneeID types.SlackUserID
+	var assigneeIDs []types.SlackUserID
 	if req.StatusId != nil {
 		statusID = types.StatusID(*req.StatusId)
 	}
-	if req.AssigneeId != nil {
-		assigneeID = types.SlackUserID(*req.AssigneeId)
+	if req.AssigneeIds != nil {
+		assigneeIDs = make([]types.SlackUserID, 0, len(*req.AssigneeIds))
+		for _, id := range *req.AssigneeIds {
+			if id == "" {
+				continue
+			}
+			assigneeIDs = append(assigneeIDs, types.SlackUserID(id))
+		}
 	}
 
 	fields := toModelFieldValues(req.Fields)
@@ -114,7 +120,7 @@ func (h *APIHandler) CreateTicket(w http.ResponseWriter, r *http.Request, worksp
 		description = *req.Description
 	}
 
-	ticket, err := h.ticketUC.Create(r.Context(), types.WorkspaceID(workspaceId), req.Title, description, statusID, assigneeID, fields)
+	ticket, err := h.ticketUC.Create(r.Context(), types.WorkspaceID(workspaceId), req.Title, description, statusID, assigneeIDs, fields)
 	if err != nil {
 		handleUseCaseError(r.Context(), w, err)
 		return
@@ -142,17 +148,23 @@ func (h *APIHandler) UpdateTicket(w http.ResponseWriter, r *http.Request, worksp
 	fields := toModelFieldValues(req.Fields)
 
 	var statusID *types.StatusID
-	var assigneeID *types.SlackUserID
+	var assigneeIDs *[]types.SlackUserID
 	if req.StatusId != nil {
 		sid := types.StatusID(*req.StatusId)
 		statusID = &sid
 	}
-	if req.AssigneeId != nil {
-		aid := types.SlackUserID(*req.AssigneeId)
-		assigneeID = &aid
+	if req.AssigneeIds != nil {
+		ids := make([]types.SlackUserID, 0, len(*req.AssigneeIds))
+		for _, id := range *req.AssigneeIds {
+			if id == "" {
+				continue
+			}
+			ids = append(ids, types.SlackUserID(id))
+		}
+		assigneeIDs = &ids
 	}
 
-	ticket, err := h.ticketUC.Update(r.Context(), types.WorkspaceID(workspaceId), types.TicketID(ticketId), req.Title, req.Description, statusID, assigneeID, fields)
+	ticket, err := h.ticketUC.Update(r.Context(), types.WorkspaceID(workspaceId), types.TicketID(ticketId), req.Title, req.Description, statusID, assigneeIDs, fields)
 	if err != nil {
 		handleUseCaseError(r.Context(), w, err)
 		return
@@ -245,22 +257,24 @@ func toTicketResponse(t *model.Ticket) Ticket {
 		})
 	}
 
+	assigneeIDs := make([]string, 0, len(t.AssigneeIDs))
+	for _, id := range t.AssigneeIDs {
+		assigneeIDs = append(assigneeIDs, string(id))
+	}
+
 	ticket := Ticket{
-		Id:        string(t.ID),
-		SeqNum:    t.SeqNum,
-		Title:     t.Title,
-		StatusId:  string(t.StatusID),
-		Fields:    fields,
-		CreatedAt: t.CreatedAt,
-		UpdatedAt: t.UpdatedAt,
+		Id:          string(t.ID),
+		SeqNum:      t.SeqNum,
+		Title:       t.Title,
+		StatusId:    string(t.StatusID),
+		AssigneeIds: assigneeIDs,
+		Fields:      fields,
+		CreatedAt:   t.CreatedAt,
+		UpdatedAt:   t.UpdatedAt,
 	}
 
 	if t.Description != "" {
 		ticket.Description = &t.Description
-	}
-	if t.AssigneeID != "" {
-		s := string(t.AssigneeID)
-		ticket.AssigneeId = &s
 	}
 	if t.ReporterSlackUserID != "" {
 		s := string(t.ReporterSlackUserID)

--- a/pkg/domain/interfaces/repository.go
+++ b/pkg/domain/interfaces/repository.go
@@ -82,15 +82,17 @@ type TicketRepository interface {
 	GetBySlackThreadTS(ctx context.Context, workspaceID types.WorkspaceID, channelID types.SlackChannelID, threadTS types.SlackThreadTS) (*model.Ticket, error)
 
 	// FinalizeTriage atomically marks the ticket as triaged, optionally updates
-	// the assignee, and records the supplied history entry. Implementations
+	// the assignees, and records the supplied history entry. Implementations
 	// MUST execute the ticket update and the history append in a single atomic
 	// step (Firestore RunTransaction or equivalent). The operation is
 	// idempotent: when the ticket is already Triaged, the call is a no-op and
 	// no additional history entry is recorded.
 	//
-	// assignee == nil leaves Ticket.AssigneeID untouched. history.ID may be
-	// empty; implementations must populate it with a generated identifier.
-	FinalizeTriage(ctx context.Context, workspaceID types.WorkspaceID, ticketID types.TicketID, assignee *types.SlackUserID, history *model.TicketHistory) error
+	// assignees == nil leaves Ticket.AssigneeIDs untouched. A non-nil pointer
+	// (even to an empty slice) replaces the assignee list wholesale.
+	// history.ID may be empty; implementations must populate it with a
+	// generated identifier.
+	FinalizeTriage(ctx context.Context, workspaceID types.WorkspaceID, ticketID types.TicketID, assignees *[]types.SlackUserID, history *model.TicketHistory) error
 }
 
 type CommentRepository interface {

--- a/pkg/domain/model/ticket.go
+++ b/pkg/domain/model/ticket.go
@@ -14,7 +14,7 @@ type Ticket struct {
 	Description         string
 	InitialMessage      string
 	StatusID            types.StatusID
-	AssigneeID          types.SlackUserID
+	AssigneeIDs         []types.SlackUserID
 	ReporterSlackUserID types.SlackUserID
 	SlackChannelID      types.SlackChannelID
 	SlackThreadTS       types.SlackThreadTS

--- a/pkg/domain/model/triage.go
+++ b/pkg/domain/model/triage.go
@@ -223,11 +223,13 @@ func (c *Complete) Validate() error {
 	return c.Assignee.Validate()
 }
 
-// AssigneeDecision captures whether the LLM picked an assignee or intentionally
-// left the ticket unassigned. Reasoning is required in either case.
+// AssigneeDecision captures whether the LLM picked one or more assignees or
+// intentionally left the ticket unassigned. Reasoning is required in either
+// case. UserIDs is empty for unassigned decisions and contains 1..N ids for
+// assigned ones.
 type AssigneeDecision struct {
 	Kind      types.AssigneeDecisionKind `json:"kind"`
-	UserID    *types.SlackUserID         `json:"user_id,omitempty"`
+	UserIDs   []types.SlackUserID        `json:"user_ids,omitempty"`
 	Reasoning string                     `json:"reasoning"`
 }
 
@@ -237,12 +239,17 @@ func (d *AssigneeDecision) Validate() error {
 	}
 	switch d.Kind {
 	case types.AssigneeAssigned:
-		if d.UserID == nil || *d.UserID == "" {
-			return goerr.New("assigned decision requires a user id")
+		if len(d.UserIDs) == 0 {
+			return goerr.New("assigned decision requires at least one user id")
+		}
+		for _, id := range d.UserIDs {
+			if id == "" {
+				return goerr.New("assigned decision contains empty user id")
+			}
 		}
 	case types.AssigneeUnassigned:
-		if d.UserID != nil {
-			return goerr.New("unassigned decision must not carry a user id")
+		if len(d.UserIDs) > 0 {
+			return goerr.New("unassigned decision must not carry user ids")
 		}
 	default:
 		return goerr.New("unknown assignee decision kind", goerr.V("kind", d.Kind))

--- a/pkg/domain/model/triage_test.go
+++ b/pkg/domain/model/triage_test.go
@@ -49,15 +49,14 @@ func validAskPlan() *model.TriagePlan {
 }
 
 func validCompletePlan() *model.TriagePlan {
-	uid := types.SlackUserID("U1")
 	return &model.TriagePlan{
 		Kind:    types.PlanComplete,
-		Message: "triageが完了しました",
+		Message: "triage completed",
 		Complete: &model.Complete{
 			Summary: "Investigation done",
 			Assignee: model.AssigneeDecision{
 				Kind:      types.AssigneeAssigned,
-				UserID:    &uid,
+				UserIDs:   []types.SlackUserID{"U1"},
 				Reasoning: "responsible for the affected service",
 			},
 		},
@@ -208,13 +207,12 @@ func TestAnswerIsValid(t *testing.T) {
 }
 
 func TestCompleteValidate(t *testing.T) {
-	uid := types.SlackUserID("U1")
 	base := func() *model.Complete {
 		return &model.Complete{
 			Summary: "summary",
 			Assignee: model.AssigneeDecision{
 				Kind:      types.AssigneeAssigned,
-				UserID:    &uid,
+				UserIDs:   []types.SlackUserID{"U1"},
 				Reasoning: "reason",
 			},
 		}
@@ -234,15 +232,26 @@ func TestCompleteValidate(t *testing.T) {
 }
 
 func TestAssigneeDecisionValidate(t *testing.T) {
-	uid := types.SlackUserID("U1")
-	t.Run("assigned ok", func(t *testing.T) {
+	t.Run("assigned single ok", func(t *testing.T) {
 		gt.NoError(t, (&model.AssigneeDecision{
-			Kind: types.AssigneeAssigned, UserID: &uid, Reasoning: "r",
+			Kind: types.AssigneeAssigned, UserIDs: []types.SlackUserID{"U1"}, Reasoning: "r",
 		}).Validate())
 	})
-	t.Run("assigned without user", func(t *testing.T) {
+	t.Run("assigned multiple ok", func(t *testing.T) {
+		gt.NoError(t, (&model.AssigneeDecision{
+			Kind:      types.AssigneeAssigned,
+			UserIDs:   []types.SlackUserID{"U1", "U2", "U3"},
+			Reasoning: "r",
+		}).Validate())
+	})
+	t.Run("assigned with empty list rejected", func(t *testing.T) {
 		gt.Error(t, (&model.AssigneeDecision{
-			Kind: types.AssigneeAssigned, UserID: nil, Reasoning: "r",
+			Kind: types.AssigneeAssigned, UserIDs: nil, Reasoning: "r",
+		}).Validate())
+	})
+	t.Run("assigned with empty id rejected", func(t *testing.T) {
+		gt.Error(t, (&model.AssigneeDecision{
+			Kind: types.AssigneeAssigned, UserIDs: []types.SlackUserID{"U1", ""}, Reasoning: "r",
 		}).Validate())
 	})
 	t.Run("unassigned ok", func(t *testing.T) {
@@ -250,14 +259,14 @@ func TestAssigneeDecisionValidate(t *testing.T) {
 			Kind: types.AssigneeUnassigned, Reasoning: "needs team review",
 		}).Validate())
 	})
-	t.Run("unassigned with user rejected", func(t *testing.T) {
+	t.Run("unassigned with users rejected", func(t *testing.T) {
 		gt.Error(t, (&model.AssigneeDecision{
-			Kind: types.AssigneeUnassigned, UserID: &uid, Reasoning: "r",
+			Kind: types.AssigneeUnassigned, UserIDs: []types.SlackUserID{"U1"}, Reasoning: "r",
 		}).Validate())
 	})
 	t.Run("missing reasoning", func(t *testing.T) {
 		gt.Error(t, (&model.AssigneeDecision{
-			Kind: types.AssigneeAssigned, UserID: &uid,
+			Kind: types.AssigneeAssigned, UserIDs: []types.SlackUserID{"U1"},
 		}).Validate())
 	})
 	t.Run("unknown kind", func(t *testing.T) {

--- a/pkg/repository/firestore/ticket.go
+++ b/pkg/repository/firestore/ticket.go
@@ -128,7 +128,7 @@ func (r *ticketRepository) Delete(ctx context.Context, workspaceID types.Workspa
 	return nil
 }
 
-func (r *ticketRepository) FinalizeTriage(ctx context.Context, workspaceID types.WorkspaceID, ticketID types.TicketID, assignee *types.SlackUserID, history *model.TicketHistory) error {
+func (r *ticketRepository) FinalizeTriage(ctx context.Context, workspaceID types.WorkspaceID, ticketID types.TicketID, assignees *[]types.SlackUserID, history *model.TicketHistory) error {
 	if history == nil {
 		return goerr.New("history entry is required")
 	}
@@ -165,8 +165,12 @@ func (r *ticketRepository) FinalizeTriage(ctx context.Context, workspaceID types
 			{Path: "Triaged", Value: true},
 			{Path: "UpdatedAt", Value: time.Now()},
 		}
-		if assignee != nil {
-			updates = append(updates, firestore.Update{Path: "AssigneeID", Value: string(*assignee)})
+		if assignees != nil {
+			ids := make([]string, len(*assignees))
+			for i, id := range *assignees {
+				ids[i] = string(id)
+			}
+			updates = append(updates, firestore.Update{Path: "AssigneeIDs", Value: ids})
 		}
 		if err := tx.Update(ticketRef, updates); err != nil {
 			return goerr.Wrap(err, "failed to update ticket")

--- a/pkg/repository/memory/ticket.go
+++ b/pkg/repository/memory/ticket.go
@@ -119,7 +119,7 @@ func (r *TicketRepo) Delete(ctx context.Context, workspaceID types.WorkspaceID, 
 	return nil
 }
 
-func (r *TicketRepo) FinalizeTriage(ctx context.Context, workspaceID types.WorkspaceID, ticketID types.TicketID, assignee *types.SlackUserID, history *model.TicketHistory) error {
+func (r *TicketRepo) FinalizeTriage(ctx context.Context, workspaceID types.WorkspaceID, ticketID types.TicketID, assignees *[]types.SlackUserID, history *model.TicketHistory) error {
 	if history == nil {
 		return goerr.New("history entry is required")
 	}
@@ -143,8 +143,8 @@ func (r *TicketRepo) FinalizeTriage(ctx context.Context, workspaceID types.Works
 
 	// Update ticket fields.
 	t.Triaged = true
-	if assignee != nil {
-		t.AssigneeID = *assignee
+	if assignees != nil {
+		t.AssigneeIDs = append([]types.SlackUserID(nil), (*assignees)...)
 	}
 	t.UpdatedAt = time.Now()
 	copied := *t

--- a/pkg/repository/triage_finalize_test.go
+++ b/pkg/repository/triage_finalize_test.go
@@ -33,17 +33,19 @@ func TestFinalizeTriage_Assigned(t *testing.T) {
 		ctx := context.Background()
 		ws := types.WorkspaceID("ws-finalize-assigned")
 		tk := newTriageTicket(t, repo, ws)
-		assignee := types.SlackUserID("U123")
+		assignees := []types.SlackUserID{"U123", "U456"}
 
-		err := repo.Ticket().FinalizeTriage(ctx, ws, tk.ID, &assignee, &model.TicketHistory{
+		err := repo.Ticket().FinalizeTriage(ctx, ws, tk.ID, &assignees, &model.TicketHistory{
 			Action:    "triage_completed",
-			ChangedBy: assignee,
+			ChangedBy: assignees[0],
 		})
 		gt.NoError(t, err)
 
 		got := gt.R1(repo.Ticket().Get(ctx, ws, tk.ID)).NoError(t)
 		gt.True(t, got.Triaged)
-		gt.S(t, string(got.AssigneeID)).Equal("U123")
+		gt.A(t, got.AssigneeIDs).Length(2)
+		gt.S(t, string(got.AssigneeIDs[0])).Equal("U123")
+		gt.S(t, string(got.AssigneeIDs[1])).Equal("U456")
 
 		histories := gt.R1(repo.TicketHistory().List(ctx, ws, tk.ID)).NoError(t)
 		gt.N(t, len(histories)).Equal(1)
@@ -65,7 +67,7 @@ func TestFinalizeTriage_Unassigned(t *testing.T) {
 
 		got := gt.R1(repo.Ticket().Get(ctx, ws, tk.ID)).NoError(t)
 		gt.True(t, got.Triaged)
-		gt.S(t, string(got.AssigneeID)).Equal("") // assignee untouched
+		gt.A(t, got.AssigneeIDs).Length(0) // assignees untouched (nil pointer means leave alone)
 
 		histories := gt.R1(repo.TicketHistory().List(ctx, ws, tk.ID)).NoError(t)
 		gt.N(t, len(histories)).Equal(1)
@@ -77,15 +79,15 @@ func TestFinalizeTriage_Idempotent(t *testing.T) {
 		ctx := context.Background()
 		ws := types.WorkspaceID("ws-finalize-idempotent")
 		tk := newTriageTicket(t, repo, ws)
-		assignee := types.SlackUserID("U1")
+		assignees := []types.SlackUserID{"U1"}
 
 		// First call: should record one history.
-		gt.NoError(t, repo.Ticket().FinalizeTriage(ctx, ws, tk.ID, &assignee, &model.TicketHistory{
+		gt.NoError(t, repo.Ticket().FinalizeTriage(ctx, ws, tk.ID, &assignees, &model.TicketHistory{
 			Action: "triage_completed",
 		}))
 
 		// Second call on already-triaged ticket: must be a no-op (no extra history).
-		gt.NoError(t, repo.Ticket().FinalizeTriage(ctx, ws, tk.ID, &assignee, &model.TicketHistory{
+		gt.NoError(t, repo.Ticket().FinalizeTriage(ctx, ws, tk.ID, &assignees, &model.TicketHistory{
 			Action: "triage_completed_again",
 		}))
 

--- a/pkg/service/slack/triage_blocks.go
+++ b/pkg/service/slack/triage_blocks.go
@@ -326,10 +326,10 @@ func BuildCompleteBlocks(ctx context.Context, comp *model.Complete) []slackgo.Bl
 
 	switch comp.Assignee.Kind {
 	case types.AssigneeAssigned:
-		if comp.Assignee.UserID != nil {
+		if mentions := joinAssigneeMentions(comp.Assignee.UserIDs); mentions != "" {
 			blocks = append(blocks, slackgo.NewSectionBlock(
 				slackgo.NewTextBlockObject(slackgo.MarkdownType,
-					loc.T(i18n.MsgTriageCompleteAssigneeMention, "user", string(*comp.Assignee.UserID)),
+					loc.T(i18n.MsgTriageCompleteAssigneeMention, "users", mentions),
 					false, false),
 				nil, nil,
 			))
@@ -426,6 +426,20 @@ func sectionLabeled(label, body string) slackgo.Block {
 		slackgo.NewTextBlockObject(slackgo.MarkdownType, text, false, false),
 		nil, nil,
 	)
+}
+
+// joinAssigneeMentions formats assignee Slack ids as space-separated mention
+// tokens (e.g. "<@U123> <@U456>"). Empty ids are skipped. Returns "" when no
+// valid id is present.
+func joinAssigneeMentions(ids []types.SlackUserID) string {
+	mentions := make([]string, 0, len(ids))
+	for _, id := range ids {
+		if id == "" {
+			continue
+		}
+		mentions = append(mentions, "<@"+string(id)+">")
+	}
+	return strings.Join(mentions, " ")
 }
 
 // escapeMrkdwn escapes Slack mrkdwn metacharacters so user-supplied content

--- a/pkg/service/slack/triage_review.go
+++ b/pkg/service/slack/triage_review.go
@@ -285,10 +285,10 @@ func completeBodyBlocks(ctx context.Context, comp *model.Complete) []slackgo.Blo
 
 	switch comp.Assignee.Kind {
 	case types.AssigneeAssigned:
-		if comp.Assignee.UserID != nil {
+		if mentions := joinAssigneeMentions(comp.Assignee.UserIDs); mentions != "" {
 			blocks = append(blocks, slackgo.NewSectionBlock(
 				slackgo.NewTextBlockObject(slackgo.MarkdownType,
-					loc.T(i18n.MsgTriageCompleteAssigneeMention, "user", string(*comp.Assignee.UserID)),
+					loc.T(i18n.MsgTriageCompleteAssigneeMention, "users", mentions),
 					false, false),
 				nil, nil,
 			))
@@ -355,9 +355,16 @@ func buildSummaryInputBlock(ctx context.Context, initial string) slackgo.Block {
 
 func buildAssigneeInputBlock(ctx context.Context, decision model.AssigneeDecision) slackgo.Block {
 	loc := i18n.From(ctx)
-	users := slackgo.NewOptionsSelectBlockElement(slackgo.OptTypeUser, nil, TriageReviewAssigneeActionID)
-	if decision.Kind == types.AssigneeAssigned && decision.UserID != nil {
-		users = users.WithInitialUser(string(*decision.UserID))
+	users := slackgo.NewOptionsMultiSelectBlockElement(slackgo.MultiOptTypeUser, nil, TriageReviewAssigneeActionID)
+	if decision.Kind == types.AssigneeAssigned && len(decision.UserIDs) > 0 {
+		initial := make([]string, 0, len(decision.UserIDs))
+		for _, id := range decision.UserIDs {
+			if id == "" {
+				continue
+			}
+			initial = append(initial, string(id))
+		}
+		users.InitialUsers = initial
 	}
 	block := slackgo.NewInputBlock(
 		TriageReviewAssigneeBlockID,

--- a/pkg/tool/internal/format/format.go
+++ b/pkg/tool/internal/format/format.go
@@ -19,6 +19,10 @@ func Ticket(t *model.Ticket, statusName string) map[string]any {
 	for k, v := range t.FieldValues {
 		fields[k] = v.Value
 	}
+	assignees := make([]string, 0, len(t.AssigneeIDs))
+	for _, id := range t.AssigneeIDs {
+		assignees = append(assignees, string(id))
+	}
 	return map[string]any{
 		"id":               string(t.ID),
 		"seq_num":          t.SeqNum,
@@ -26,7 +30,7 @@ func Ticket(t *model.Ticket, statusName string) map[string]any {
 		"description":      t.Description,
 		"status_id":        string(t.StatusID),
 		"status_name":      statusName,
-		"assignee":         string(t.AssigneeID),
+		"assignees":        assignees,
 		"reporter":         string(t.ReporterSlackUserID),
 		"slack_channel_id": string(t.SlackChannelID),
 		"slack_thread_ts":  string(t.SlackThreadTS),

--- a/pkg/tool/internal/format/format_test.go
+++ b/pkg/tool/internal/format/format_test.go
@@ -19,7 +19,7 @@ func TestTicket(t *testing.T) {
 		Title:               "boom",
 		Description:         "details",
 		StatusID:            "open",
-		AssigneeID:          "U-A",
+		AssigneeIDs:         []types.SlackUserID{"U-A", "U-B"},
 		ReporterSlackUserID: "U-R",
 		SlackChannelID:      "C-1",
 		SlackThreadTS:       "1.0",
@@ -33,6 +33,7 @@ func TestTicket(t *testing.T) {
 	gt.Equal(t, got["id"], "tk-1")
 	gt.Equal(t, got["seq_num"].(int64), int64(42))
 	gt.Equal(t, got["status_name"], "Open")
+	gt.Equal(t, got["assignees"].([]string), []string{"U-A", "U-B"})
 	fields := got["fields"].(map[string]any)
 	gt.Equal(t, fields["severity"], "high")
 	gt.Equal(t, got["created_at"], "2026-01-02T03:04:05Z")

--- a/pkg/usecase/ticket.go
+++ b/pkg/usecase/ticket.go
@@ -33,7 +33,7 @@ func NewTicketUseCase(repo interfaces.Repository, registry *model.WorkspaceRegis
 	}
 }
 
-func (uc *TicketUseCase) Create(ctx context.Context, workspaceID types.WorkspaceID, title, description string, statusID types.StatusID, assigneeID types.SlackUserID, fields map[string]model.FieldValue) (*model.Ticket, error) {
+func (uc *TicketUseCase) Create(ctx context.Context, workspaceID types.WorkspaceID, title, description string, statusID types.StatusID, assigneeIDs []types.SlackUserID, fields map[string]model.FieldValue) (*model.Ticket, error) {
 	entry, ok := uc.registry.Get(workspaceID)
 	if !ok {
 		return nil, goerr.New("workspace not found", goerr.V("workspace_id", workspaceID), goerr.Tag(errutil.TagNotFound))
@@ -50,7 +50,7 @@ func (uc *TicketUseCase) Create(ctx context.Context, workspaceID types.Workspace
 		Title:       title,
 		Description: description,
 		StatusID:    statusID,
-		AssigneeID:  assigneeID,
+		AssigneeIDs: append([]types.SlackUserID(nil), assigneeIDs...),
 		FieldValues: fields,
 		CreatedAt:   now,
 		UpdatedAt:   now,
@@ -106,7 +106,7 @@ func (uc *TicketUseCase) List(ctx context.Context, workspaceID types.WorkspaceID
 	return tickets, nil
 }
 
-func (uc *TicketUseCase) Update(ctx context.Context, workspaceID types.WorkspaceID, ticketID types.TicketID, title, description *string, statusID *types.StatusID, assigneeID *types.SlackUserID, fields map[string]model.FieldValue) (*model.Ticket, error) {
+func (uc *TicketUseCase) Update(ctx context.Context, workspaceID types.WorkspaceID, ticketID types.TicketID, title, description *string, statusID *types.StatusID, assigneeIDs *[]types.SlackUserID, fields map[string]model.FieldValue) (*model.Ticket, error) {
 	existing, err := uc.repo.Ticket().Get(ctx, workspaceID, ticketID)
 	if err != nil {
 		return nil, goerr.Wrap(err, "failed to get ticket for update")
@@ -123,8 +123,8 @@ func (uc *TicketUseCase) Update(ctx context.Context, workspaceID types.Workspace
 	if statusID != nil {
 		existing.StatusID = *statusID
 	}
-	if assigneeID != nil {
-		existing.AssigneeID = *assigneeID
+	if assigneeIDs != nil {
+		existing.AssigneeIDs = append([]types.SlackUserID(nil), (*assigneeIDs)...)
 	}
 	if fields != nil {
 		if existing.FieldValues == nil {

--- a/pkg/usecase/ticket_test.go
+++ b/pkg/usecase/ticket_test.go
@@ -43,7 +43,7 @@ func TestTicketUseCase_Create(t *testing.T) {
 	uc, _ := setupTicketUseCase(t)
 	ctx := context.Background()
 
-	ticket := gt.R1(uc.Create(ctx, "ws-test", "My Ticket", "desc", "", "", nil)).NoError(t)
+	ticket := gt.R1(uc.Create(ctx, "ws-test", "My Ticket", "desc", "", nil, nil)).NoError(t)
 	gt.S(t, ticket.Title).Equal("My Ticket")
 	gt.S(t, string(ticket.StatusID)).Equal("open")
 	gt.S(t, string(ticket.ID)).NotEqual("")
@@ -53,7 +53,7 @@ func TestTicketUseCase_Create_WithStatus(t *testing.T) {
 	uc, _ := setupTicketUseCase(t)
 	ctx := context.Background()
 
-	ticket := gt.R1(uc.Create(ctx, "ws-test", "Custom Status", "", "in-progress", "", nil)).NoError(t)
+	ticket := gt.R1(uc.Create(ctx, "ws-test", "Custom Status", "", "in-progress", nil, nil)).NoError(t)
 	gt.S(t, string(ticket.StatusID)).Equal("in-progress")
 }
 
@@ -64,7 +64,7 @@ func TestTicketUseCase_Create_WithFields(t *testing.T) {
 	fields := map[string]model.FieldValue{
 		"priority": {FieldID: "priority", Type: types.FieldTypeSelect, Value: "high"},
 	}
-	ticket := gt.R1(uc.Create(ctx, "ws-test", "With Fields", "", "", "", fields)).NoError(t)
+	ticket := gt.R1(uc.Create(ctx, "ws-test", "With Fields", "", "", nil, fields)).NoError(t)
 	gt.M(t, ticket.FieldValues).HasKey("priority")
 	gt.V(t, ticket.FieldValues["priority"].Value).Equal(any("high"))
 }
@@ -73,7 +73,7 @@ func TestTicketUseCase_Create_UnknownWorkspace(t *testing.T) {
 	uc, _ := setupTicketUseCase(t)
 	ctx := context.Background()
 
-	_, err := uc.Create(ctx, "nonexistent", "Title", "", "", "", nil)
+	_, err := uc.Create(ctx, "nonexistent", "Title", "", "", nil, nil)
 	gt.Error(t, err)
 }
 
@@ -81,7 +81,7 @@ func TestTicketUseCase_GetAndList(t *testing.T) {
 	uc, _ := setupTicketUseCase(t)
 	ctx := context.Background()
 
-	created := gt.R1(uc.Create(ctx, "ws-test", "T1", "", "", "", nil)).NoError(t)
+	created := gt.R1(uc.Create(ctx, "ws-test", "T1", "", "", nil, nil)).NoError(t)
 
 	got := gt.R1(uc.Get(ctx, "ws-test", created.ID)).NoError(t)
 	gt.S(t, got.Title).Equal("T1")
@@ -94,9 +94,9 @@ func TestTicketUseCase_List_FilterByClosed(t *testing.T) {
 	uc, _ := setupTicketUseCase(t)
 	ctx := context.Background()
 
-	gt.R1(uc.Create(ctx, "ws-test", "Open Ticket", "", "open", "", nil)).NoError(t)
-	gt.R1(uc.Create(ctx, "ws-test", "Resolved Ticket", "", "resolved", "", nil)).NoError(t)
-	gt.R1(uc.Create(ctx, "ws-test", "Closed Ticket", "", "closed", "", nil)).NoError(t)
+	gt.R1(uc.Create(ctx, "ws-test", "Open Ticket", "", "open", nil, nil)).NoError(t)
+	gt.R1(uc.Create(ctx, "ws-test", "Resolved Ticket", "", "resolved", nil, nil)).NoError(t)
+	gt.R1(uc.Create(ctx, "ws-test", "Closed Ticket", "", "closed", nil, nil)).NoError(t)
 
 	isClosed := true
 	closedTickets := gt.R1(uc.List(ctx, "ws-test", &isClosed, nil)).NoError(t)
@@ -111,7 +111,7 @@ func TestTicketUseCase_Update(t *testing.T) {
 	uc, _ := setupTicketUseCase(t)
 	ctx := context.Background()
 
-	created := gt.R1(uc.Create(ctx, "ws-test", "Original", "desc", "", "", nil)).NoError(t)
+	created := gt.R1(uc.Create(ctx, "ws-test", "Original", "desc", "", nil, nil)).NoError(t)
 
 	newTitle := "Updated"
 	newStatus := types.StatusID("in-progress")
@@ -128,7 +128,7 @@ func TestTicketUseCase_Update_MergeFields(t *testing.T) {
 	initial := map[string]model.FieldValue{
 		"priority": {FieldID: "priority", Value: "high"},
 	}
-	created := gt.R1(uc.Create(ctx, "ws-test", "T", "", "", "", initial)).NoError(t)
+	created := gt.R1(uc.Create(ctx, "ws-test", "T", "", "", nil, initial)).NoError(t)
 
 	newFields := map[string]model.FieldValue{
 		"category": {FieldID: "category", Value: "bug"},
@@ -142,7 +142,7 @@ func TestTicketUseCase_Delete(t *testing.T) {
 	uc, _ := setupTicketUseCase(t)
 	ctx := context.Background()
 
-	created := gt.R1(uc.Create(ctx, "ws-test", "To Delete", "", "", "", nil)).NoError(t)
+	created := gt.R1(uc.Create(ctx, "ws-test", "To Delete", "", "", nil, nil)).NoError(t)
 	gt.NoError(t, uc.Delete(ctx, "ws-test", created.ID))
 
 	_, err := uc.Get(ctx, "ws-test", created.ID)
@@ -153,7 +153,7 @@ func TestTicketUseCase_Create_RecordsHistory(t *testing.T) {
 	uc, _ := setupTicketUseCase(t)
 	ctx := context.Background()
 
-	ticket := gt.R1(uc.Create(ctx, "ws-test", "History Test", "", "", "", nil)).NoError(t)
+	ticket := gt.R1(uc.Create(ctx, "ws-test", "History Test", "", "", nil, nil)).NoError(t)
 
 	histories := gt.R1(uc.ListHistory(ctx, "ws-test", ticket.ID)).NoError(t)
 	gt.A(t, histories).Length(1)
@@ -167,7 +167,7 @@ func TestTicketUseCase_Update_StatusChange_RecordsHistory(t *testing.T) {
 	uc, _ := setupTicketUseCase(t)
 	ctx := context.Background()
 
-	ticket := gt.R1(uc.Create(ctx, "ws-test", "Status Change", "", "", "", nil)).NoError(t)
+	ticket := gt.R1(uc.Create(ctx, "ws-test", "Status Change", "", "", nil, nil)).NoError(t)
 
 	newStatus := types.StatusID("in-progress")
 	gt.R1(uc.Update(ctx, "ws-test", ticket.ID, nil, nil, &newStatus, nil, nil)).NoError(t)
@@ -184,7 +184,7 @@ func TestTicketUseCase_Update_NoStatusChange_NoHistory(t *testing.T) {
 	uc, _ := setupTicketUseCase(t)
 	ctx := context.Background()
 
-	ticket := gt.R1(uc.Create(ctx, "ws-test", "No Status Change", "", "", "", nil)).NoError(t)
+	ticket := gt.R1(uc.Create(ctx, "ws-test", "No Status Change", "", "", nil, nil)).NoError(t)
 
 	newTitle := "Updated Title"
 	gt.R1(uc.Update(ctx, "ws-test", ticket.ID, &newTitle, nil, nil, nil, nil)).NoError(t)

--- a/pkg/usecase/triage/complete.go
+++ b/pkg/usecase/triage/complete.go
@@ -26,9 +26,10 @@ func (e *PlanExecutor) finalizeComplete(ctx context.Context, ticket *model.Ticke
 		return goerr.New("finalizeComplete called with nil Complete")
 	}
 
-	var assignee *types.SlackUserID
-	if comp.Assignee.Kind == types.AssigneeAssigned && comp.Assignee.UserID != nil {
-		assignee = comp.Assignee.UserID
+	var assignees *[]types.SlackUserID
+	if comp.Assignee.Kind == types.AssigneeAssigned && len(comp.Assignee.UserIDs) > 0 {
+		ids := append([]types.SlackUserID(nil), comp.Assignee.UserIDs...)
+		assignees = &ids
 	}
 
 	// Persist the LLM's (or human-edited) Title and Summary as the ticket's
@@ -55,7 +56,7 @@ func (e *PlanExecutor) finalizeComplete(ctx context.Context, ticket *model.Ticke
 		ChangedBy: ticket.ReporterSlackUserID, // best-effort: the bot has no Slack user id of its own.
 	}
 
-	if err := e.repo.Ticket().FinalizeTriage(ctx, ticket.WorkspaceID, ticket.ID, assignee, history); err != nil {
+	if err := e.repo.Ticket().FinalizeTriage(ctx, ticket.WorkspaceID, ticket.ID, assignees, history); err != nil {
 		return goerr.Wrap(err, "finalize triage in repository", goerr.V("ticket_id", ticket.ID))
 	}
 	return nil

--- a/pkg/usecase/triage/executor_test.go
+++ b/pkg/usecase/triage/executor_test.go
@@ -128,11 +128,12 @@ func TestExecutorRun_LLMProposesComplete_FinalizesTriage(t *testing.T) {
 
 	gt.NoError(t, exec.RunForTest(context.Background(), tWS, ticket.ID))
 
-	// Persistence: Triaged flag flipped, assignee from completePlanJSON persisted.
+	// Persistence: Triaged flag flipped, assignees from completePlanJSON persisted.
 	got, err := repo.Ticket().Get(context.Background(), tWS, ticket.ID)
 	gt.NoError(t, err)
 	gt.True(t, got.Triaged)
-	gt.Equal(t, got.AssigneeID, types.SlackUserID("U123"))
+	gt.A(t, got.AssigneeIDs).Length(1)
+	gt.Equal(t, got.AssigneeIDs[0], types.SlackUserID("U123"))
 
 	// Slack: hand-off summary posted in the ticket thread.
 	gt.A(t, slack.posts).Length(1)

--- a/pkg/usecase/triage/handoff.go
+++ b/pkg/usecase/triage/handoff.go
@@ -51,8 +51,17 @@ func assigneeMentionText(comp *model.Complete) string {
 	if comp == nil {
 		return ""
 	}
-	if comp.Assignee.Kind == types.AssigneeAssigned && comp.Assignee.UserID != nil {
-		return fmt.Sprintf("<@%s>", string(*comp.Assignee.UserID))
+	if comp.Assignee.Kind == types.AssigneeAssigned && len(comp.Assignee.UserIDs) > 0 {
+		mentions := make([]string, 0, len(comp.Assignee.UserIDs))
+		for _, id := range comp.Assignee.UserIDs {
+			if id == "" {
+				continue
+			}
+			mentions = append(mentions, fmt.Sprintf("<@%s>", string(id)))
+		}
+		if len(mentions) > 0 {
+			return strings.Join(mentions, " ")
+		}
 	}
 	return "@channel"
 }

--- a/pkg/usecase/triage/history_test.go
+++ b/pkg/usecase/triage/history_test.go
@@ -99,7 +99,7 @@ const completePlanJSON = `{
     "summary": "Investigation done",
     "assignee": {
       "kind": "assigned",
-      "user_id": "U123",
+      "user_ids": ["U123"],
       "reasoning": "owner of the affected service"
     }
   }

--- a/pkg/usecase/triage/review.go
+++ b/pkg/usecase/triage/review.go
@@ -347,11 +347,17 @@ func applyEditModalState(ctx context.Context, base *model.Complete, schema *doma
 			}
 		}
 		if v, ok := lookupAction(state, slackService.TriageReviewAssigneeBlockID, slackService.TriageReviewAssigneeActionID); ok {
-			if u := v.SelectedUser; u != "" {
-				uid := types.SlackUserID(u)
+			ids := make([]types.SlackUserID, 0, len(v.SelectedUsers))
+			for _, u := range v.SelectedUsers {
+				if u == "" {
+					continue
+				}
+				ids = append(ids, types.SlackUserID(u))
+			}
+			if len(ids) > 0 {
 				out.Assignee = model.AssigneeDecision{
 					Kind:      types.AssigneeAssigned,
-					UserID:    &uid,
+					UserIDs:   ids,
 					Reasoning: base.Assignee.Reasoning,
 				}
 			} else {

--- a/pkg/usecase/triage/review_test.go
+++ b/pkg/usecase/triage/review_test.go
@@ -33,7 +33,8 @@ func TestHandleReviewSubmit_HappyPath_FinalizesAndPostsFollowup(t *testing.T) {
 
 	got := gt.R1(repo.Ticket().Get(context.Background(), tWS, ticket.ID)).NoError(t)
 	gt.True(t, got.Triaged)
-	gt.Equal(t, got.AssigneeID, types.SlackUserID("U123"))
+	gt.A(t, got.AssigneeIDs).Length(1)
+	gt.Equal(t, got.AssigneeIDs[0], types.SlackUserID("U123"))
 
 	// Original review message is rewritten to remove buttons (1 update); the
 	// LLM hand-off message is posted as a fresh thread reply (1 post).
@@ -102,7 +103,7 @@ func TestHandleReviewEditSubmit_AppliesEditedAssigneeAndFinalizes(t *testing.T) 
 			slackService.TriageReviewSummaryActionID: {Value: "Edited summary"},
 		},
 		slackService.TriageReviewAssigneeBlockID: {
-			slackService.TriageReviewAssigneeActionID: {SelectedUser: "U999"},
+			slackService.TriageReviewAssigneeActionID: {SelectedUsers: []string{"U999", "U888"}},
 		},
 	}}
 
@@ -116,8 +117,10 @@ func TestHandleReviewEditSubmit_AppliesEditedAssigneeAndFinalizes(t *testing.T) 
 
 	got := gt.R1(repo.Ticket().Get(context.Background(), tWS, ticket.ID)).NoError(t)
 	gt.True(t, got.Triaged)
-	// finalizeComplete used the edited assignee, not the planner's U123.
-	gt.Equal(t, got.AssigneeID, types.SlackUserID("U999"))
+	// finalizeComplete used the edited assignees, not the planner's [U123].
+	gt.A(t, got.AssigneeIDs).Length(2)
+	gt.Equal(t, got.AssigneeIDs[0], types.SlackUserID("U999"))
+	gt.Equal(t, got.AssigneeIDs[1], types.SlackUserID("U888"))
 	// Edited title / summary are persisted onto the ticket itself so the
 	// values the user confirmed in the modal become the authoritative
 	// ticket headline + body.

--- a/pkg/usecase/triage/schema.go
+++ b/pkg/usecase/triage/schema.go
@@ -152,7 +152,7 @@ func completeSchema() *gollem.Parameter {
 			},
 			"assignee": {
 				Type:        gollem.TypeObject,
-				Description: "Assignment decision. Use kind=unassigned when you cannot confidently pick a single owner.",
+				Description: "Assignment decision. Use kind=unassigned when you cannot confidently pick at least one owner.",
 				Required:    true,
 				Properties: map[string]*gollem.Parameter{
 					"kind": {
@@ -161,13 +161,14 @@ func completeSchema() *gollem.Parameter {
 						Required:    true,
 						Enum:        []string{"assigned", "unassigned"},
 					},
-					"user_id": {
-						Type:        gollem.TypeString,
-						Description: "Slack user id (e.g. 'U123ABC'). Required when kind=='assigned'; omit when kind=='unassigned'.",
+					"user_ids": {
+						Type:        gollem.TypeArray,
+						Description: "One or more Slack user ids (e.g. ['U123ABC']). Required and non-empty when kind=='assigned'; omit when kind=='unassigned'.",
+						Items:       &gollem.Parameter{Type: gollem.TypeString},
 					},
 					"reasoning": {
 						Type:        gollem.TypeString,
-						Description: "Why this person (or why nobody is being assigned).",
+						Description: "Why these people (or why nobody is being assigned).",
 						Required:    true,
 						MinLength:   intPtr(1),
 					},

--- a/pkg/usecase/triage/usecase_test.go
+++ b/pkg/usecase/triage/usecase_test.go
@@ -558,7 +558,8 @@ func TestLifecycle_TicketCreate_Ask_Submit_Complete(t *testing.T) {
 	// === Step 3: planner resumed and completed triage =====================
 	got := gt.R1(repo.Ticket().Get(ctx, wsID, ticket.ID)).NoError(t)
 	gt.True(t, got.Triaged)
-	gt.Equal(t, got.AssigneeID, types.SlackUserID("U123"))
+	gt.A(t, got.AssigneeIDs).Length(1)
+	gt.Equal(t, got.AssigneeIDs[0], types.SlackUserID("U123"))
 
 	// Triage posted the hand-off summary in the ticket thread (in addition
 	// to the original ask form).

--- a/pkg/utils/i18n/en.go
+++ b/pkg/utils/i18n/en.go
@@ -22,7 +22,7 @@ var en = map[MsgKey]string{
 
 	MsgTriageCompleteHeaderAssigned:   "Triage completed",
 	MsgTriageCompleteHeaderUnassigned: "Triage completed (no assignee)",
-	MsgTriageCompleteAssigneeMention:  "<@{user}>, please take this over.",
+	MsgTriageCompleteAssigneeMention:  "{users}, please take this over.",
 	MsgTriageCompleteSectionSummary:   "*Summary*",
 	MsgTriageCompleteSectionFindings:  "*Key findings*",
 	MsgTriageCompleteSectionAnswers:   "*Reporter answers*",

--- a/pkg/utils/i18n/ja.go
+++ b/pkg/utils/i18n/ja.go
@@ -22,7 +22,7 @@ var ja = map[MsgKey]string{
 
 	MsgTriageCompleteHeaderAssigned:   "triageが完了しました",
 	MsgTriageCompleteHeaderUnassigned: "triageが完了しました（担当者未定）",
-	MsgTriageCompleteAssigneeMention:  "<@{user}> 対応をお願いします。",
+	MsgTriageCompleteAssigneeMention:  "{users} 対応をお願いします。",
 	MsgTriageCompleteSectionSummary:   "*サマリ*",
 	MsgTriageCompleteSectionFindings:  "*重要事項*",
 	MsgTriageCompleteSectionAnswers:   "*依頼者からの回答*",


### PR DESCRIPTION
## Summary
- Replace `Ticket.AssigneeID string` with `AssigneeIDs []SlackUserID` and `AssigneeDecision.UserID` with `UserIDs` across domain, repository, usecase, HTTP API, and Firestore wire format.
- Switch the triage review modal to Slack's `multi_users_select`, update the LLM schema (`assignee.user_ids: array<string>`), and render hand-off messages mentioning every selected user.
- Frontend ticket detail / list / kanban now read and edit a multi-assignee list. Kanban swimlanes by assignee duplicate-render a card per lane it belongs to; dropping replaces the lane's owner, dropping on Unassigned clears the list.
- No backwards-compatibility for the old single-`assigneeId` field — the API, generated types, Firestore schema, and LLM contract all flip wholesale.

## Test plan
- [x] `task test` (Go unit + integration) — all green
- [x] `task test:e2e` (Playwright, 27 tests) — all green; `ticket-detail-assignee.spec.ts` rewritten to cover add / append / remove-one / clear-all / mid-edit cases
- [x] `tsc --noEmit` — clean
- [x] `go vet ./...` — clean
- [ ] Manual smoke against a workspace once the branch is deployed