### PR TITLE
refactor: require slack channel ID and drop #name resolution

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -70,7 +70,7 @@ verification. The full provisioning walkthrough lives in [docs/slack.md](slack.m
 |---|---|---|
 | `--slack-client-id` | `SHEPHERD_SLACK_CLIENT_ID` | Slack OAuth client ID for Sign in with Slack. |
 | `--slack-client-secret` | `SHEPHERD_SLACK_CLIENT_SECRET` | Slack OAuth client secret. |
-| `--slack-bot-token` | `SHEPHERD_SLACK_BOT_TOKEN` | Bot token (`xoxb-...`) used to read channels, post replies, resolve `#channel-name` to channel IDs, and invoke the Slack-backed LLM tools. |
+| `--slack-bot-token` | `SHEPHERD_SLACK_BOT_TOKEN` | Bot token (`xoxb-...`) used to read channels, post replies, and invoke the Slack-backed LLM tools. |
 | `--slack-signing-secret` | `SHEPHERD_SLACK_SIGNING_SECRET` | Signing secret used to verify incoming events on `/hooks/slack/event` and interactive payloads on `/hooks/slack/interaction`. |
 | `--no-authn` | `SHEPHERD_NO_AUTHN` | Development-only: bypass OAuth and authenticate every request as the given Slack User ID. Mutually intended-exclusive with the OAuth flags. |
 
@@ -167,7 +167,7 @@ default_status = "open"
 closed_statuses = ["resolved"]
 
 [slack]
-channel = "#team-support"
+channel = "C0123456789"
 
 [[statuses]]
 id = "open"
@@ -201,7 +201,7 @@ A fuller example, including custom fields and labels, lives at
 
 | Key | Type | Required | Description |
 |---|---|---|---|
-| `channel` | string | yes | Slack channel to monitor. Either a channel ID (`C0123456789`) or a channel name prefixed with `#` (`#team-support`). When the `#name` form is used, `--slack-bot-token` is required at startup so Shepherd can resolve the name to an ID. |
+| `channel` | string | yes | Slack channel ID to monitor (e.g. `C0123456789`). Must match `^[CDG][A-Z0-9]{8,}$`. The `#channel-name` form is **not** supported — copy the channel ID from Slack via "View channel details → About → Channel ID". |
 
 ### `[[statuses]]`
 
@@ -271,5 +271,5 @@ Pointers for the most frequent misconfigurations:
 | `agent storage is required: set either --agent-storage-fs-dir or --agent-storage-gcs-bucket` | Neither agent-storage backend was configured. |
 | `--agent-storage-fs-dir and --agent-storage-gcs-bucket are mutually exclusive` | Both backends were set; pick one. |
 | `--base-url is required when Slack OAuth is enabled` | Slack OAuth flags are set but `--base-url` is empty. |
-| `channel name resolution requires --slack-bot-token` | Workspace TOML uses `#channel-name` form but no bot token is configured. |
+| `invalid slack channel format` | Workspace TOML's `[slack] channel` is not a valid Slack channel ID. Channel names (`#team-support`) are no longer supported — use the channel ID (`C0123456789`) instead. |
 | `firestore-project-id is required when using firestore backend` | `--repository-backend=firestore` was set without `--firestore-project-id`. |

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -155,7 +155,7 @@ default_status = "open"
 closed_statuses = ["resolved"]
 
 [slack]
-channel = "#team-support"
+channel = "C0123456789"
 
 [[statuses]]
 id = "open"

--- a/docs/slack.md
+++ b/docs/slack.md
@@ -33,9 +33,7 @@ Add the following **Bot Token Scopes**:
 | `chat:write` | Post ticket creation replies in threads |
 | `app_mentions:read` | Receive `app_mention` events for LLM-assisted replies |
 | `channels:history` | Read messages in public channels |
-| `channels:read` | Resolve `#channel-name` to channel ID |
 | `groups:history` | Read messages in private channels |
-| `groups:read` | Resolve private `#channel-name` to channel ID |
 | `users:read` | Fetch user profile (name) for NoAuthn mode and `slack_get_user_info` LLM tool |
 | `users:read.email` | Fetch user email for NoAuthn mode |
 | `search:read` | Required by the `slack_search_messages` LLM tool (Slack `search.messages` API). User-token scope on classic apps; on Slack Marketplace apps this scope must be approved for bot tokens or the search tool returns "not_allowed_token_type". |
@@ -165,21 +163,20 @@ shepherd serve \
 
 ### Workspace Configuration
 
-Each workspace's TOML config must specify the Slack channel to monitor:
+Each workspace's TOML config must specify the Slack channel ID to monitor:
 
 ```toml
 [slack]
-channel = "#my-channel"       # Channel name (resolved to ID at startup via Slack API)
+channel = "C0123456789"       # Channel ID (must match ^[CDG][A-Z0-9]{8,}$)
 ```
 
-Or use a raw channel ID directly:
+The `#channel-name` form is **not** supported. To find a channel's ID:
 
-```toml
-[slack]
-channel = "C0123456789"       # Channel ID (used as-is)
-```
+1. Open the channel in the Slack desktop or web client
+2. Click the channel name in the header to open **View channel details**
+3. Scroll to **About** at the bottom; the **Channel ID** is shown there with a copy button
 
-When using `#channel-name` format, `--slack-bot-token` must be set so Shepherd can resolve the name to a channel ID at startup. The bot also needs the `channels:read` and `groups:read` scopes.
+If you previously used the `#channel-name` form, replace it with the channel ID copied this way — Shepherd will refuse to start with a clear error message otherwise.
 
 ## 8. Invite the Bot
 

--- a/pkg/cli/config/config.go
+++ b/pkg/cli/config/config.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"context"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -17,6 +16,18 @@ import (
 )
 
 var idPattern = regexp.MustCompile(`^[a-z0-9]+(-[a-z0-9]+)*$`)
+
+// slackChannelIDPattern matches a Slack channel/DM/group ID.
+// Prefix [CDG] is documented at:
+//
+//	https://docs.slack.dev/apis/web-api/using-the-conversations-api/
+//
+// (C: public/private channel, D: DM, G: legacy private channel + mpim.)
+// The body character class [A-Z0-9] and the length lower bound (8) are
+// implementation conventions, not part of any documented contract; no
+// upper bound is enforced because Slack does not guarantee channel ID
+// length stability.
+var slackChannelIDPattern = regexp.MustCompile(`^[CDG][A-Z0-9]{8,}$`)
 
 type WorkspaceFiles struct {
 	paths []string
@@ -124,6 +135,18 @@ func (a *AppConfig) Validate() error {
 	if a.Slack.Channel == "" {
 		return goerr.Wrap(ErrMissingChannelID, "[slack] channel is required",
 			goerr.V(WorkspaceIDKey, wsID))
+	}
+	if strings.HasPrefix(a.Slack.Channel, "#") {
+		return goerr.Wrap(ErrInvalidChannelFormat,
+			`[slack] channel must be a Slack channel ID (e.g. "C0123456789"); the "#channel-name" form is no longer supported. Copy the channel ID from Slack via "View channel details → About → Channel ID"`,
+			goerr.V(WorkspaceIDKey, wsID),
+			goerr.V("channel", a.Slack.Channel))
+	}
+	if !slackChannelIDPattern.MatchString(a.Slack.Channel) {
+		return goerr.Wrap(ErrInvalidChannelFormat,
+			`[slack] channel must be a Slack channel ID matching ^[CDG][A-Z0-9]{8,}$ (e.g. "C0123456789")`,
+			goerr.V(WorkspaceIDKey, wsID),
+			goerr.V("channel", a.Slack.Channel))
 	}
 
 	// [triage] auto defaults to false (zero value), which means a human review
@@ -300,41 +323,21 @@ func loadSingleWorkspaceConfig(path string) (*WorkspaceConfig, error) {
 	}, nil
 }
 
-type ChannelResolver func(ctx context.Context, name string) (string, error)
-
-func BuildRegistry(ctx context.Context, configs []*WorkspaceConfig, resolve ChannelResolver) (*model.WorkspaceRegistry, error) {
+func BuildRegistry(configs []*WorkspaceConfig) (*model.WorkspaceRegistry, error) {
 	registry := model.NewWorkspaceRegistry()
 	logger := logging.Default()
 
 	for _, wc := range configs {
-		channelID := wc.SlackChannel
-		if strings.HasPrefix(channelID, "#") {
-			if resolve == nil {
-				return nil, goerr.New("channel name resolution requires --slack-bot-token",
-					goerr.V(WorkspaceIDKey, wc.ID),
-					goerr.V("channel", wc.SlackChannel))
-			}
-			name := strings.TrimPrefix(channelID, "#")
-			resolved, err := resolve(ctx, name)
-			if err != nil {
-				return nil, goerr.Wrap(err, "failed to resolve slack channel name",
-					goerr.V(WorkspaceIDKey, wc.ID),
-					goerr.V("channel", wc.SlackChannel))
-			}
-			logger.Info("Resolved slack channel", "name", wc.SlackChannel, "id", resolved)
-			channelID = resolved
-		}
-
 		registry.Register(&model.WorkspaceEntry{
 			Workspace: model.Workspace{
 				ID:   types.WorkspaceID(wc.ID),
 				Name: wc.Name,
 			},
-			FieldSchema:         wc.FieldSchema,
-			SlackChannelID:      types.SlackChannelID(channelID),
-			AutoTriage:          wc.AutoTriage,
+			FieldSchema:    wc.FieldSchema,
+			SlackChannelID: types.SlackChannelID(wc.SlackChannel),
+			AutoTriage:     wc.AutoTriage,
 		})
-		logger.Info("Registered workspace", "id", wc.ID, "name", wc.Name, "channel", channelID)
+		logger.Info("Registered workspace", "id", wc.ID, "name", wc.Name, "channel", wc.SlackChannel)
 	}
 	return registry, nil
 }

--- a/pkg/cli/config/config.go
+++ b/pkg/cli/config/config.go
@@ -323,7 +323,7 @@ func loadSingleWorkspaceConfig(path string) (*WorkspaceConfig, error) {
 	}, nil
 }
 
-func BuildRegistry(configs []*WorkspaceConfig) (*model.WorkspaceRegistry, error) {
+func BuildRegistry(configs []*WorkspaceConfig) *model.WorkspaceRegistry {
 	registry := model.NewWorkspaceRegistry()
 	logger := logging.Default()
 
@@ -339,5 +339,5 @@ func BuildRegistry(configs []*WorkspaceConfig) (*model.WorkspaceRegistry, error)
 		})
 		logger.Info("Registered workspace", "id", wc.ID, "name", wc.Name, "channel", wc.SlackChannel)
 	}
-	return registry, nil
+	return registry
 }

--- a/pkg/cli/config/config_test.go
+++ b/pkg/cli/config/config_test.go
@@ -1,7 +1,7 @@
 package config_test
 
 import (
-	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -79,7 +79,7 @@ func TestLoadWorkspaceConfigs_Directory(t *testing.T) {
 [workspace]
 id = "ws-two"
 [slack]
-channel = "C9999"
+channel = "C9999000000"
 [[statuses]]
 id = "open"
 name = "Open"
@@ -99,7 +99,7 @@ func TestLoadWorkspaceConfigs_DuplicateWorkspaceID(t *testing.T) {
 [workspace]
 id = "test-ws"
 [slack]
-channel = "C9999"
+channel = "C9999000000"
 [[statuses]]
 id = "open"
 name = "Open"
@@ -137,7 +137,7 @@ func TestLoadWorkspaceConfigs_MissingWorkspaceID(t *testing.T) {
 [workspace]
 name = "No ID"
 [slack]
-channel = "C111"
+channel = "C1110000000"
 [[statuses]]
 id = "open"
 name = "Open"
@@ -155,7 +155,7 @@ func TestLoadWorkspaceConfigs_InvalidWorkspaceID(t *testing.T) {
 [workspace]
 id = "INVALID_ID"
 [slack]
-channel = "C111"
+channel = "C1110000000"
 [[statuses]]
 id = "open"
 name = "Open"
@@ -202,7 +202,7 @@ func TestLoadWorkspaceConfigs_DefaultLabels(t *testing.T) {
 [workspace]
 id = "test-ws"
 [slack]
-channel = "C111"
+channel = "C1110000000"
 [[statuses]]
 id = "open"
 name = "Open"
@@ -221,7 +221,7 @@ func TestLoadWorkspaceConfigs_DefaultStatusFromFirst(t *testing.T) {
 [workspace]
 id = "test-ws"
 [slack]
-channel = "C111"
+channel = "C1110000000"
 [[statuses]]
 id = "new"
 name = "New"
@@ -243,7 +243,7 @@ func TestLoadWorkspaceConfigs_NameFallsBackToID(t *testing.T) {
 [workspace]
 id = "my-ws"
 [slack]
-channel = "C111"
+channel = "C1110000000"
 [[statuses]]
 id = "open"
 name = "Open"
@@ -261,8 +261,7 @@ func TestBuildRegistry(t *testing.T) {
 
 	configs := gt.R1(config.LoadWorkspaceConfigs([]string{dir})).NoError(t)
 
-	ctx := context.Background()
-	registry := gt.R1(config.BuildRegistry(ctx, configs, nil)).NoError(t)
+	registry := gt.R1(config.BuildRegistry(configs)).NoError(t)
 	entry, ok := registry.Get(types.WorkspaceID("test-ws"))
 	gt.B(t, ok).True()
 	gt.S(t, entry.Workspace.Name).Equal("Test Workspace")
@@ -298,9 +297,87 @@ func TestBuildRegistry_PropagatesAutoTriage(t *testing.T) {
 	writeToml(t, dir, "ws.toml", tomlBody)
 
 	configs := gt.R1(config.LoadWorkspaceConfigs([]string{dir})).NoError(t)
-	ctx := context.Background()
-	registry := gt.R1(config.BuildRegistry(ctx, configs, nil)).NoError(t)
+	registry := gt.R1(config.BuildRegistry(configs)).NoError(t)
 	entry, ok := registry.Get(types.WorkspaceID("test-ws"))
 	gt.B(t, ok).True()
 	gt.B(t, entry.AutoTriage).True()
+}
+
+func TestLoadWorkspaceConfigs_RejectsHashChannelName(t *testing.T) {
+	dir := t.TempDir()
+	body := `
+[workspace]
+id = "test-ws"
+[slack]
+channel = "#team-support"
+[[statuses]]
+id = "open"
+name = "Open"
+color = "#fff"
+`
+	path := writeToml(t, dir, "bad.toml", body)
+
+	_, err := config.LoadWorkspaceConfigs([]string{path})
+	gt.Error(t, err)
+	gt.B(t, errors.Is(err, config.ErrInvalidChannelFormat)).True()
+	// Migration hint should be in the error so operators can self-recover.
+	gt.S(t, err.Error()).Contains("no longer supported")
+	gt.S(t, err.Error()).Contains("View channel details")
+}
+
+func TestLoadWorkspaceConfigs_RejectsInvalidChannelFormat(t *testing.T) {
+	cases := map[string]string{
+		"lowercase":      "c0123abcd1",
+		"contains_space": "C 1234567",
+		"too_short":      "C12",
+		"user_id":        "U01234567",
+		"hyphen":         "C-12345678",
+	}
+	for name, channel := range cases {
+		t.Run(name, func(t *testing.T) {
+			dir := t.TempDir()
+			body := `
+[workspace]
+id = "test-ws"
+[slack]
+channel = "` + channel + `"
+[[statuses]]
+id = "open"
+name = "Open"
+color = "#fff"
+`
+			path := writeToml(t, dir, "bad.toml", body)
+
+			_, err := config.LoadWorkspaceConfigs([]string{path})
+			gt.Error(t, err)
+			gt.B(t, errors.Is(err, config.ErrInvalidChannelFormat)).True()
+		})
+	}
+}
+
+func TestLoadWorkspaceConfigs_AcceptsValidChannelIDs(t *testing.T) {
+	cases := map[string]string{
+		"public_channel":  "C0123456789",
+		"dm":              "D01ABC23DE",
+		"legacy_or_mpim":  "G99XYZ12345",
+	}
+	for name, channel := range cases {
+		t.Run(name, func(t *testing.T) {
+			dir := t.TempDir()
+			body := `
+[workspace]
+id = "test-ws"
+[slack]
+channel = "` + channel + `"
+[[statuses]]
+id = "open"
+name = "Open"
+color = "#fff"
+`
+			path := writeToml(t, dir, "ok.toml", body)
+
+			configs := gt.R1(config.LoadWorkspaceConfigs([]string{path})).NoError(t)
+			gt.S(t, configs[0].SlackChannel).Equal(channel)
+		})
+	}
 }

--- a/pkg/cli/config/config_test.go
+++ b/pkg/cli/config/config_test.go
@@ -261,7 +261,7 @@ func TestBuildRegistry(t *testing.T) {
 
 	configs := gt.R1(config.LoadWorkspaceConfigs([]string{dir})).NoError(t)
 
-	registry := gt.R1(config.BuildRegistry(configs)).NoError(t)
+	registry := config.BuildRegistry(configs)
 	entry, ok := registry.Get(types.WorkspaceID("test-ws"))
 	gt.B(t, ok).True()
 	gt.S(t, entry.Workspace.Name).Equal("Test Workspace")
@@ -297,7 +297,7 @@ func TestBuildRegistry_PropagatesAutoTriage(t *testing.T) {
 	writeToml(t, dir, "ws.toml", tomlBody)
 
 	configs := gt.R1(config.LoadWorkspaceConfigs([]string{dir})).NoError(t)
-	registry := gt.R1(config.BuildRegistry(configs)).NoError(t)
+	registry := config.BuildRegistry(configs)
 	entry, ok := registry.Get(types.WorkspaceID("test-ws"))
 	gt.B(t, ok).True()
 	gt.B(t, entry.AutoTriage).True()

--- a/pkg/cli/config/errors.go
+++ b/pkg/cli/config/errors.go
@@ -11,6 +11,7 @@ var (
 	ErrInvalidWorkspaceID   = goerr.New("invalid workspace ID")
 	ErrDuplicateWorkspaceID = goerr.New("duplicate workspace ID")
 	ErrMissingChannelID     = goerr.New("slack channel is required")
+	ErrInvalidChannelFormat = goerr.New("invalid slack channel format")
 	ErrDuplicateChannelID   = goerr.New("duplicate slack channel across workspaces")
 )
 

--- a/pkg/cli/serve.go
+++ b/pkg/cli/serve.go
@@ -121,10 +121,7 @@ func cmdServe() *cli.Command {
 				return goerr.Wrap(err, "failed to load workspace configs")
 			}
 
-			registry, err := config.BuildRegistry(workspaceConfigs)
-			if err != nil {
-				return goerr.Wrap(err, "failed to build workspace registry")
-			}
+			registry := config.BuildRegistry(workspaceConfigs)
 
 			repo, err := repoCfg.Configure(ctx)
 			if err != nil {

--- a/pkg/cli/serve.go
+++ b/pkg/cli/serve.go
@@ -121,13 +121,7 @@ func cmdServe() *cli.Command {
 				return goerr.Wrap(err, "failed to load workspace configs")
 			}
 
-			var channelResolver config.ChannelResolver
-			if slackCfg.BotToken() != "" {
-				slackClient := slackCfg.NewSlackClient()
-				channelResolver = slackClient.ResolveChannelName
-			}
-
-			registry, err := config.BuildRegistry(ctx, workspaceConfigs, channelResolver)
+			registry, err := config.BuildRegistry(workspaceConfigs)
 			if err != nil {
 				return goerr.Wrap(err, "failed to build workspace registry")
 			}

--- a/pkg/service/slack/slack.go
+++ b/pkg/service/slack/slack.go
@@ -330,34 +330,3 @@ func convertMessages(msgs []slackgo.Message) []*Message {
 	return out
 }
 
-func (c *Client) ResolveChannelName(ctx context.Context, name string) (string, error) {
-	var cursor string
-	for {
-		params := &slackgo.GetConversationsParameters{
-			Cursor:          cursor,
-			Limit:           200,
-			Types:           []string{"public_channel", "private_channel"},
-			ExcludeArchived: true,
-		}
-		channels, nextCursor, err := c.api.GetConversationsContext(ctx, params)
-		if err != nil {
-			return "", goerr.Wrap(err, "failed to list slack channels",
-				goerr.V("channel_name", name),
-				goerr.Tag(errutil.TagSlackError),
-			)
-		}
-		for _, ch := range channels {
-			if ch.Name == name {
-				return ch.ID, nil
-			}
-		}
-		if nextCursor == "" {
-			break
-		}
-		cursor = nextCursor
-	}
-	return "", goerr.New("slack channel not found",
-		goerr.V("channel_name", name),
-		goerr.Tag(errutil.TagSlackError),
-	)
-}


### PR DESCRIPTION
## Summary

- Drop the startup `conversations.list` lookup that resolved `#channel-name` to a channel ID. The Tier 2 rate limit + lack of retry made `serve` crash on large workspaces.
- `[slack] channel` now must be a Slack channel ID matching `^[CDG][A-Z0-9]{8,}$`. The `#channel-name` form is rejected at TOML load with a migration hint pointing to Slack's **View channel details → About → Channel ID** flow.
- Remove the now-unused `channels:read` / `groups:read` bot scopes and the `ChannelResolver` plumbing; `BuildRegistry` no longer needs `ctx` or a resolver.

## Breaking change

Workspace TOMLs that used `channel = "#team-support"` will fail to load. Replace the value with the channel ID copied from Slack. The error message itself includes the migration steps so operators can self-recover from the log alone.

The prefix `[CDG]` is per Slack's [Using the Conversations API](https://docs.slack.dev/apis/web-api/using-the-conversations-api/) (`C` = public/private channel, `G` = legacy private + mpim, `D` = DM). The character class and length lower bound are documented in code as implementation conventions, not contract.

## Test plan

- [x] `task test` — all Go tests pass
- [x] `task build` — frontend + Go binary build green
- [x] New `pkg/cli/config/config_test.go` cases:
  - [x] `RejectsHashChannelName` (verifies migration hint in error)
  - [x] `RejectsInvalidChannelFormat` (lowercase / space / too_short / user_id / hyphen)
  - [x] `AcceptsValidChannelIDs` (C / D / G prefixes)
- [x] Existing `TestBuildRegistry` / `TestBuildRegistry_PropagatesAutoTriage` updated to the new single-arg signature
- [x] Docs updated (`configuration.md`, `slack.md`, `setup.md`) and grep'd for stray `#channel-name` references