### PR TITLE
refactor: simplify triage AssigneeDecision and enable multi-assignee

### DIFF
--- a/pkg/domain/model/triage.go
+++ b/pkg/domain/model/triage.go
@@ -225,34 +225,27 @@ func (c *Complete) Validate() error {
 
 // AssigneeDecision captures whether the LLM picked one or more assignees or
 // intentionally left the ticket unassigned. Reasoning is required in either
-// case. UserIDs is empty for unassigned decisions and contains 1..N ids for
-// assigned ones.
+// case; an empty UserIDs list means "unassigned" and a non-empty list means
+// "assigned" — the same information `kind` previously encoded redundantly.
 type AssigneeDecision struct {
-	Kind      types.AssigneeDecisionKind `json:"kind"`
-	UserIDs   []types.SlackUserID        `json:"user_ids,omitempty"`
-	Reasoning string                     `json:"reasoning"`
+	UserIDs   []types.SlackUserID `json:"user_ids,omitempty"`
+	Reasoning string              `json:"reasoning"`
+}
+
+// Assigned reports whether the decision picks at least one concrete owner.
+// Unassigned decisions are simply the absence of any user id.
+func (d *AssigneeDecision) Assigned() bool {
+	return len(d.UserIDs) > 0
 }
 
 func (d *AssigneeDecision) Validate() error {
 	if d.Reasoning == "" {
 		return goerr.New("assignee reasoning is empty")
 	}
-	switch d.Kind {
-	case types.AssigneeAssigned:
-		if len(d.UserIDs) == 0 {
-			return goerr.New("assigned decision requires at least one user id")
+	for _, id := range d.UserIDs {
+		if id == "" {
+			return goerr.New("assignee decision contains empty user id")
 		}
-		for _, id := range d.UserIDs {
-			if id == "" {
-				return goerr.New("assigned decision contains empty user id")
-			}
-		}
-	case types.AssigneeUnassigned:
-		if len(d.UserIDs) > 0 {
-			return goerr.New("unassigned decision must not carry user ids")
-		}
-	default:
-		return goerr.New("unknown assignee decision kind", goerr.V("kind", d.Kind))
 	}
 	return nil
 }

--- a/pkg/domain/model/triage_test.go
+++ b/pkg/domain/model/triage_test.go
@@ -55,7 +55,6 @@ func validCompletePlan() *model.TriagePlan {
 		Complete: &model.Complete{
 			Description: "Investigation done",
 			Assignee: model.AssigneeDecision{
-				Kind:      types.AssigneeAssigned,
 				UserIDs:   []types.SlackUserID{"U1"},
 				Reasoning: "responsible for the affected service",
 			},
@@ -211,7 +210,6 @@ func TestCompleteValidate(t *testing.T) {
 		return &model.Complete{
 			Description: "description",
 			Assignee: model.AssigneeDecision{
-				Kind:      types.AssigneeAssigned,
 				UserIDs:   []types.SlackUserID{"U1"},
 				Reasoning: "reason",
 			},
@@ -233,45 +231,36 @@ func TestCompleteValidate(t *testing.T) {
 
 func TestAssigneeDecisionValidate(t *testing.T) {
 	t.Run("assigned single ok", func(t *testing.T) {
-		gt.NoError(t, (&model.AssigneeDecision{
-			Kind: types.AssigneeAssigned, UserIDs: []types.SlackUserID{"U1"}, Reasoning: "r",
-		}).Validate())
+		d := &model.AssigneeDecision{UserIDs: []types.SlackUserID{"U1"}, Reasoning: "r"}
+		gt.NoError(t, d.Validate())
+		gt.True(t, d.Assigned())
 	})
 	t.Run("assigned multiple ok", func(t *testing.T) {
-		gt.NoError(t, (&model.AssigneeDecision{
-			Kind:      types.AssigneeAssigned,
+		d := &model.AssigneeDecision{
 			UserIDs:   []types.SlackUserID{"U1", "U2", "U3"},
 			Reasoning: "r",
-		}).Validate())
+		}
+		gt.NoError(t, d.Validate())
+		gt.True(t, d.Assigned())
 	})
-	t.Run("assigned with empty list rejected", func(t *testing.T) {
+	t.Run("empty user id rejected", func(t *testing.T) {
 		gt.Error(t, (&model.AssigneeDecision{
-			Kind: types.AssigneeAssigned, UserIDs: nil, Reasoning: "r",
+			UserIDs: []types.SlackUserID{"U1", ""}, Reasoning: "r",
 		}).Validate())
 	})
-	t.Run("assigned with empty id rejected", func(t *testing.T) {
+	t.Run("unassigned ok with nil list", func(t *testing.T) {
+		d := &model.AssigneeDecision{Reasoning: "needs team review"}
+		gt.NoError(t, d.Validate())
+		gt.False(t, d.Assigned())
+	})
+	t.Run("unassigned ok with empty list", func(t *testing.T) {
+		d := &model.AssigneeDecision{UserIDs: []types.SlackUserID{}, Reasoning: "needs team review"}
+		gt.NoError(t, d.Validate())
+		gt.False(t, d.Assigned())
+	})
+	t.Run("missing reasoning rejected", func(t *testing.T) {
 		gt.Error(t, (&model.AssigneeDecision{
-			Kind: types.AssigneeAssigned, UserIDs: []types.SlackUserID{"U1", ""}, Reasoning: "r",
-		}).Validate())
-	})
-	t.Run("unassigned ok", func(t *testing.T) {
-		gt.NoError(t, (&model.AssigneeDecision{
-			Kind: types.AssigneeUnassigned, Reasoning: "needs team review",
-		}).Validate())
-	})
-	t.Run("unassigned with users rejected", func(t *testing.T) {
-		gt.Error(t, (&model.AssigneeDecision{
-			Kind: types.AssigneeUnassigned, UserIDs: []types.SlackUserID{"U1"}, Reasoning: "r",
-		}).Validate())
-	})
-	t.Run("missing reasoning", func(t *testing.T) {
-		gt.Error(t, (&model.AssigneeDecision{
-			Kind: types.AssigneeAssigned, UserIDs: []types.SlackUserID{"U1"},
-		}).Validate())
-	})
-	t.Run("unknown kind", func(t *testing.T) {
-		gt.Error(t, (&model.AssigneeDecision{
-			Kind: types.AssigneeDecisionKind("bogus"), Reasoning: "r",
+			UserIDs: []types.SlackUserID{"U1"},
 		}).Validate())
 	})
 

--- a/pkg/domain/types/triage.go
+++ b/pkg/domain/types/triage.go
@@ -27,12 +27,3 @@ const (
 	PlanAsk         PlanKind = "ask"
 	PlanComplete    PlanKind = "complete"
 )
-
-// AssigneeDecisionKind expresses whether the LLM decided to assign someone or
-// intentionally left the ticket unassigned.
-type AssigneeDecisionKind string
-
-const (
-	AssigneeAssigned   AssigneeDecisionKind = "assigned"
-	AssigneeUnassigned AssigneeDecisionKind = "unassigned"
-)

--- a/pkg/service/slack/triage_blocks.go
+++ b/pkg/service/slack/triage_blocks.go
@@ -333,7 +333,7 @@ func BuildCompleteBlocks(ctx context.Context, ref TicketRef, comp *model.Complet
 	loc := i18n.From(ctx)
 
 	var headerKey i18n.MsgKey
-	if comp.Assignee.Kind == types.AssigneeAssigned {
+	if comp.Assignee.Assigned() {
 		headerKey = i18n.MsgTriageCompleteHeaderAssigned
 	} else {
 		headerKey = i18n.MsgTriageCompleteHeaderUnassigned
@@ -354,8 +354,7 @@ func BuildCompleteBlocks(ctx context.Context, ref TicketRef, comp *model.Complet
 		))
 	}
 
-	switch comp.Assignee.Kind {
-	case types.AssigneeAssigned:
+	if comp.Assignee.Assigned() {
 		if mentions := joinAssigneeMentions(comp.Assignee.UserIDs); mentions != "" {
 			blocks = append(blocks, slackgo.NewSectionBlock(
 				slackgo.NewTextBlockObject(slackgo.MarkdownType,
@@ -371,7 +370,7 @@ func BuildCompleteBlocks(ctx context.Context, ref TicketRef, comp *model.Complet
 					false, false),
 			))
 		}
-	case types.AssigneeUnassigned:
+	} else {
 		blocks = append(blocks, slackgo.NewSectionBlock(
 			slackgo.NewTextBlockObject(slackgo.MarkdownType,
 				loc.T(i18n.MsgTriageCompleteUnassignedReason, "reason", comp.Assignee.Reasoning),

--- a/pkg/service/slack/triage_review.go
+++ b/pkg/service/slack/triage_review.go
@@ -307,8 +307,7 @@ func completeBodyBlocks(ctx context.Context, comp *model.Complete) []slackgo.Blo
 		))
 	}
 
-	switch comp.Assignee.Kind {
-	case types.AssigneeAssigned:
+	if comp.Assignee.Assigned() {
 		if mentions := joinAssigneeMentions(comp.Assignee.UserIDs); mentions != "" {
 			blocks = append(blocks, slackgo.NewSectionBlock(
 				slackgo.NewTextBlockObject(slackgo.MarkdownType,
@@ -324,7 +323,7 @@ func completeBodyBlocks(ctx context.Context, comp *model.Complete) []slackgo.Blo
 					false, false),
 			))
 		}
-	case types.AssigneeUnassigned:
+	} else {
 		blocks = append(blocks, slackgo.NewSectionBlock(
 			slackgo.NewTextBlockObject(slackgo.MarkdownType,
 				loc.T(i18n.MsgTriageCompleteUnassignedReason, "reason", comp.Assignee.Reasoning),
@@ -384,7 +383,7 @@ func buildAssigneeInputBlock(ctx context.Context, decision model.AssigneeDecisio
 	placeholder := slackgo.NewTextBlockObject(slackgo.PlainTextType,
 		loc.T(i18n.MsgTriageReviewFieldSelectPlaceholder), false, false)
 	users := slackgo.NewOptionsMultiSelectBlockElement(slackgo.MultiOptTypeUser, placeholder, TriageReviewAssigneeActionID)
-	if decision.Kind == types.AssigneeAssigned && len(decision.UserIDs) > 0 {
+	if decision.Assigned() {
 		initial := make([]string, 0, len(decision.UserIDs))
 		for _, id := range decision.UserIDs {
 			if id == "" {

--- a/pkg/usecase/prompt/prompt_test.go
+++ b/pkg/usecase/prompt/prompt_test.go
@@ -74,8 +74,8 @@ func TestRenderTriagePlan_FullInput(t *testing.T) {
 		"<@U123>",
 		"acceptance_criteria",
 		"unassigned",
-		"one or more",
 		"user_ids",
+		"empty array",
 	} {
 		if !strings.Contains(got, want) {
 			t.Errorf("triage_plan prompt missing %q\n---\n%s", want, got)
@@ -85,9 +85,12 @@ func TestRenderTriagePlan_FullInput(t *testing.T) {
 	for _, banned := range []string{
 		"a single user",
 		"a single owner",
+		`kind: "assigned"`,
+		`kind: "unassigned"`,
+		`kind=='assigned'`,
 	} {
 		if strings.Contains(got, banned) {
-			t.Errorf("triage_plan prompt must not assert single-assignee constraint %q\n---\n%s", banned, got)
+			t.Errorf("triage_plan prompt must not reference removed kind discriminator %q\n---\n%s", banned, got)
 		}
 	}
 }

--- a/pkg/usecase/prompt/prompt_test.go
+++ b/pkg/usecase/prompt/prompt_test.go
@@ -74,9 +74,20 @@ func TestRenderTriagePlan_FullInput(t *testing.T) {
 		"<@U123>",
 		"acceptance_criteria",
 		"unassigned",
+		"one or more",
+		"user_ids",
 	} {
 		if !strings.Contains(got, want) {
 			t.Errorf("triage_plan prompt missing %q\n---\n%s", want, got)
+		}
+	}
+
+	for _, banned := range []string{
+		"a single user",
+		"a single owner",
+	} {
+		if strings.Contains(got, banned) {
+			t.Errorf("triage_plan prompt must not assert single-assignee constraint %q\n---\n%s", banned, got)
 		}
 	}
 }

--- a/pkg/usecase/prompt/triage_plan.md
+++ b/pkg/usecase/prompt/triage_plan.md
@@ -42,9 +42,10 @@ When you build subtasks for `propose_investigate`:
 
 ## Completion (`propose_complete`)
 
-- The `assignee` decision is binary: either hand the ticket to one or more concrete owners (`kind: "assigned"` with `user_ids` containing 1..N real Slack user ids, plus reasoning) or intentionally leave it unassigned (`kind: "unassigned"` with reasoning explaining why no confident owner can be picked).
-- `user_ids` is an array of Slack user id strings (e.g. `["U123ABC"]` or `["U123ABC", "U456DEF"]`). Add a second or third owner only when ownership genuinely spans people — e.g. the work straddles two teams, or the on-call rotation pairs primary + backup. Prefer the smallest correct set; do not pad the list "just in case".
-- When in doubt, prefer `unassigned`. Misrouting a ticket — to one person or to many — is worse than letting the team decide.
+- `assignee.user_ids` carries the assignment: an array of real Slack user id strings (e.g. `["U123ABC"]` or `["U123ABC", "U456DEF"]`) when you can confidently pick owners, or an empty array (or omit the field) to leave the ticket unassigned.
+- Add a second or third owner only when ownership genuinely spans people — e.g. the work straddles two teams, or the on-call rotation pairs primary + backup. Prefer the smallest correct set; do not pad the list "just in case".
+- `assignee.reasoning` is required either way: explain why these people were picked, or why no confident owner can be chosen.
+- When in doubt, leave `user_ids` empty. Misrouting a ticket — to one person or to many — is worse than letting the team decide.
 - `description` is the markdown the assignee reads first. Keep it tight.
 - Use `key_findings` (bullets), `next_steps` (bullets), `similar_tickets` (ticket ids), and `answer_summary` (label → reporter answer summary) to give the assignee actionable context.
 {{- if .AutoFillFields }}

--- a/pkg/usecase/prompt/triage_plan.md
+++ b/pkg/usecase/prompt/triage_plan.md
@@ -42,8 +42,9 @@ When you build subtasks for `propose_investigate`:
 
 ## Completion (`propose_complete`)
 
-- The `assignee` decision is binary: either pick a single user (`kind: "assigned"` with a real Slack user id and reasoning) or intentionally leave it unassigned (`kind: "unassigned"` with reasoning explaining why a single owner cannot be confidently chosen).
-- When in doubt, prefer `unassigned`. Misrouting a ticket is worse than letting the team decide.
+- The `assignee` decision is binary: either hand the ticket to one or more concrete owners (`kind: "assigned"` with `user_ids` containing 1..N real Slack user ids, plus reasoning) or intentionally leave it unassigned (`kind: "unassigned"` with reasoning explaining why no confident owner can be picked).
+- `user_ids` is an array of Slack user id strings (e.g. `["U123ABC"]` or `["U123ABC", "U456DEF"]`). Add a second or third owner only when ownership genuinely spans people — e.g. the work straddles two teams, or the on-call rotation pairs primary + backup. Prefer the smallest correct set; do not pad the list "just in case".
+- When in doubt, prefer `unassigned`. Misrouting a ticket — to one person or to many — is worse than letting the team decide.
 - `description` is the markdown the assignee reads first. Keep it tight.
 - Use `key_findings` (bullets), `next_steps` (bullets), `similar_tickets` (ticket ids), and `answer_summary` (label → reporter answer summary) to give the assignee actionable context.
 {{- if .AutoFillFields }}

--- a/pkg/usecase/triage/complete.go
+++ b/pkg/usecase/triage/complete.go
@@ -28,7 +28,7 @@ func (e *PlanExecutor) finalizeComplete(ctx context.Context, ticket *model.Ticke
 	}
 
 	var assignees *[]types.SlackUserID
-	if comp.Assignee.Kind == types.AssigneeAssigned && len(comp.Assignee.UserIDs) > 0 {
+	if comp.Assignee.Assigned() {
 		ids := append([]types.SlackUserID(nil), comp.Assignee.UserIDs...)
 		assignees = &ids
 	}

--- a/pkg/usecase/triage/handoff.go
+++ b/pkg/usecase/triage/handoff.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/m-mizutani/gollem"
 	"github.com/m-mizutani/shepherd/pkg/domain/model"
-	"github.com/m-mizutani/shepherd/pkg/domain/types"
 	"github.com/m-mizutani/shepherd/pkg/utils/i18n"
 )
 
@@ -51,7 +50,7 @@ func assigneeMentionText(comp *model.Complete) string {
 	if comp == nil {
 		return ""
 	}
-	if comp.Assignee.Kind == types.AssigneeAssigned && len(comp.Assignee.UserIDs) > 0 {
+	if comp.Assignee.Assigned() {
 		mentions := make([]string, 0, len(comp.Assignee.UserIDs))
 		for _, id := range comp.Assignee.UserIDs {
 			if id == "" {

--- a/pkg/usecase/triage/llm_test.go
+++ b/pkg/usecase/triage/llm_test.go
@@ -44,7 +44,6 @@ func completePlan(values map[string]any) *model.TriagePlan {
 		Complete: &model.Complete{
 			Description: "ok",
 			Assignee: model.AssigneeDecision{
-				Kind:      types.AssigneeAssigned,
 				UserIDs:   []types.SlackUserID{"U123"},
 				Reasoning: "owner",
 			},

--- a/pkg/usecase/triage/review.go
+++ b/pkg/usecase/triage/review.go
@@ -354,18 +354,12 @@ func applyEditModalState(ctx context.Context, base *model.Complete, schema *doma
 				}
 				ids = append(ids, types.SlackUserID(u))
 			}
-			if len(ids) > 0 {
-				out.Assignee = model.AssigneeDecision{
-					Kind:      types.AssigneeAssigned,
-					UserIDs:   ids,
-					Reasoning: base.Assignee.Reasoning,
-				}
-			} else {
-				// Cleared selection: reset to unassigned, preserving reasoning.
-				out.Assignee = model.AssigneeDecision{
-					Kind:      types.AssigneeUnassigned,
-					Reasoning: base.Assignee.Reasoning,
-				}
+			// An empty list means the operator cleared the multi-select; we
+			// keep the reasoning so a later edit can restore an assignee
+			// without re-deriving "why" from scratch.
+			out.Assignee = model.AssigneeDecision{
+				UserIDs:   ids,
+				Reasoning: base.Assignee.Reasoning,
 			}
 		}
 	}

--- a/pkg/usecase/triage/schema.go
+++ b/pkg/usecase/triage/schema.go
@@ -161,23 +161,17 @@ func completeSchema(autoFill []domainConfig.FieldDefinition) *gollem.Parameter {
 			},
 			"assignee": {
 				Type:        gollem.TypeObject,
-				Description: "Assignment decision. Use kind=unassigned when you cannot confidently pick at least one owner.",
+				Description: "Assignment decision. Populate user_ids with one or more Slack user ids when you can confidently pick owners; leave user_ids empty (or omit it) to leave the ticket unassigned for the team to pick up.",
 				Required:    true,
 				Properties: map[string]*gollem.Parameter{
-					"kind": {
-						Type:        gollem.TypeString,
-						Description: "Either 'assigned' or 'unassigned'.",
-						Required:    true,
-						Enum:        []string{"assigned", "unassigned"},
-					},
 					"user_ids": {
 						Type:        gollem.TypeArray,
-						Description: "One or more Slack user ids (e.g. ['U123ABC']). Required and non-empty when kind=='assigned'; omit when kind=='unassigned'.",
+						Description: "Slack user id strings (e.g. ['U123ABC'] or ['U123ABC', 'U456DEF']). Empty / omitted means unassigned.",
 						Items:       &gollem.Parameter{Type: gollem.TypeString},
 					},
 					"reasoning": {
 						Type:        gollem.TypeString,
-						Description: "Why these people (or why nobody is being assigned).",
+						Description: "Why these people were picked, or why no confident owner can be chosen.",
 						Required:    true,
 						MinLength:   intPtr(1),
 					},


### PR DESCRIPTION
## Summary

Two related changes to the triage assignment flow:

### 1. `fix`: enable multi-assignee triage in the planner prompt

The Slack edit modal (`multi_users_select`), LLM JSON schema (`user_ids: array`), Firestore persistence (`AssigneeIDs []string`), and frontend already supported multiple assignees per ticket — that work landed in #28. However, the triage planner prompt (`pkg/usecase/prompt/triage_plan.md`) still instructed the LLM to "pick a single user … or leave it unassigned", so the model consistently returned only one assignee even when ownership genuinely spanned multiple people.

Rewritten the `propose_complete` guidance to explain that `user_ids` is an array (`["U1"]` or `["U1","U2"]` or empty for unassigned), with a "smallest correct set; when in doubt, unassigned" guardrail to prevent the model from over-assigning.

### 2. `refactor`: drop the redundant `kind` discriminator from `AssigneeDecision`

`AssigneeDecision.Kind` (`"assigned"` / `"unassigned"`) was fully redundant with `len(UserIDs) > 0` — the validator already enforced `kind == assigned ⟺ len(UserIDs) > 0`, so the field encoded the same bit twice. Removed:

- `Kind` field from `model.AssigneeDecision`
- `types.AssigneeDecisionKind` type and the `AssigneeAssigned` / `AssigneeUnassigned` constants
- The `kind` property from the LLM JSON schema and prompt
- All `Kind == AssigneeAssigned` checks at call sites (`complete.go`, `handoff.go`, `triage_blocks.go`, `triage_review.go`)

Added an `AssigneeDecision.Assigned()` helper for readability where call sites previously read `Kind == AssigneeAssigned && len(UserIDs) > 0`.

The Slack edit modal, persistence (`Ticket.AssigneeIDs`), and hand-off rendering are unaffected — they already keyed off the user-id list rather than `Kind`.

## Test plan

- [x] `go test ./pkg/...` (all packages green)
- [x] `TestAssigneeDecisionValidate` rewritten to reflect the new shape (assigned ⟺ non-empty list, missing reasoning rejected, empty user id rejected)
- [x] `TestRenderTriagePlan_FullInput` asserts the prompt mentions `user_ids` / `empty array` and does **not** reference the removed `kind` discriminator
- [x] `docs/slack.md` already describes the modal as multi-user — no doc drift