### PR TITLE
feat: add Slack empty-mention quick actions and unify ticket change notifications

### DIFF
--- a/docs/slack.md
+++ b/docs/slack.md
@@ -96,6 +96,8 @@ This endpoint is signed with the same signing secret as `/hooks/slack/event` and
 | `triage_review_edit` | Anyone clicked **Edit** on the triage review message. Bot opens the Edit modal synchronously via `views.open` (Slack's `trigger_id` is only valid for ~3 seconds). |
 | `triage_review_submit` | Anyone clicked **Submit** on the triage review message. Bot finalises the planner's latest `PlanComplete` proposal as-is, posts a follow-up "Submitted" message into the thread mentioning every selected assignee. The original review message is not rewritten. |
 | `triage_review_reinvestigate` | Anyone clicked **Re-investigate** on the triage review message. Bot opens the instruction modal synchronously via `views.open`. |
+| `quick_actions_assignee_select` | User changed the assignee multi-select in an empty-mention quick-actions menu. Bot updates the ticket's assignees through `TicketUseCase.Update`, which fires the unified `NotifyTicketChange` notification. |
+| `quick_actions_status_select` | User changed the status select in an empty-mention quick-actions menu. Bot updates the ticket's status through `TicketUseCase.Update`, which fires the unified `NotifyTicketChange` notification. |
 
 ### `view_submission`
 
@@ -186,9 +188,26 @@ Invite the Shepherd bot to each channel configured in your workspace TOML files:
 /invite @Shepherd
 ```
 
+## Empty Mentions: Quick Actions Menu
+
+When a user mentions the bot **with no body text** (just `@Shepherd` on its own) inside a ticket thread, Shepherd posts an inline **Quick Actions** menu into the thread instead of an LLM reply. The menu lets the user flip the ticket's assignee or status without leaving Slack:
+
+- A `multi_users_select` seeded with the ticket's current assignees.
+- A `static_select` seeded with the ticket's current status, populated from the workspace's `FieldSchema.Statuses`.
+
+Each select dispatches a `block_actions` payload to `/hooks/slack/interaction`; the bot resolves the underlying ticket from the message's `channel_id` + `thread_ts` and applies the change through the same `TicketUseCase.Update` entry point used by the HTTP API.
+
+The empty-mention branch works **regardless of whether an LLM provider is configured**, since it does not call any LLM.
+
+## Ticket Change Notifications (unified)
+
+Whenever a ticket's status or assignee changes — through the HTTP API (Web UI), the empty-mention quick-actions menu, or any future surface that goes through `TicketUseCase.Update` — Shepherd posts a single context-block notification into the ticket's Slack thread summarising the transition. When status and assignee change in the same update, both rows render in one message rather than two.
+
+The notification is delivered through `TicketChangeNotifier.NotifyTicketChange`, implemented by the Slack service `Client`. The triage flow's hand-off message (posted at the end of a successful triage submit) is intentionally a separate message produced by the triage usecase, since it carries planner output beyond the scope of a status / assignee transition.
+
 ## LLM-Assisted Replies (required)
 
-When a user mentions the bot (`@Shepherd ...`) inside a ticket thread, Shepherd generates a reply using an LLM. The bot reads the ticket title, description, prior comments, and the latest mention, then posts a generated answer in the thread.
+When a user mentions the bot (`@Shepherd ...`) **with body text** inside a ticket thread, Shepherd generates a reply using an LLM. The bot reads the ticket title, description, prior comments, and the latest mention, then posts a generated answer in the thread. Empty mentions take the Quick Actions path described above instead.
 
 Configuring an LLM provider is **required** — `serve` aborts at startup when no provider is set. Choose one of the providers below:
 

--- a/pkg/cli/serve.go
+++ b/pkg/cli/serve.go
@@ -219,11 +219,14 @@ func cmdServe() *cli.Command {
 			}
 
 			if slackUC != nil {
+				ticketUC := usecaseroot.NewTicketUseCase(repo, registry, slackClient)
+				quickUC := usecaseroot.NewQuickActionsUseCase(repo, registry, ticketUC)
 				serverOpts = append(serverOpts, httpController.WithSlack(httpController.SlackConfig{
 					SigningSecret: slackCfg.SignSecret(),
 					SlackUC:       slackUC,
 					Notifier:      slackClient,
 					TriageUC:      triageUC,
+					QuickUC:       quickUC,
 				}))
 			}
 

--- a/pkg/controller/http/handler.go
+++ b/pkg/controller/http/handler.go
@@ -29,7 +29,7 @@ type APIHandler struct {
 
 var _ ServerInterface = (*APIHandler)(nil)
 
-func NewAPIHandler(registry *model.WorkspaceRegistry, repo interfaces.Repository, notifier usecase.StatusChangeNotifier, slackUC *usecase.SlackUseCase, sourceUC *source.UseCase, catalog *tool.Catalog, promptUC *prompt.UseCase) *APIHandler {
+func NewAPIHandler(registry *model.WorkspaceRegistry, repo interfaces.Repository, notifier usecase.TicketChangeNotifier, slackUC *usecase.SlackUseCase, sourceUC *source.UseCase, catalog *tool.Catalog, promptUC *prompt.UseCase) *APIHandler {
 	return &APIHandler{
 		workspaceUC: usecase.NewWorkspaceUseCase(registry),
 		ticketUC:    usecase.NewTicketUseCase(repo, registry, notifier),

--- a/pkg/controller/http/server.go
+++ b/pkg/controller/http/server.go
@@ -46,8 +46,9 @@ func WithPrompt(promptUC *prompt.UseCase) ServerOption {
 type SlackConfig struct {
 	SigningSecret string
 	SlackUC       *usecase.SlackUseCase
-	Notifier      usecase.StatusChangeNotifier
+	Notifier      usecase.TicketChangeNotifier
 	TriageUC      TriageInteractionsUC
+	QuickUC       QuickActionsInteractionsUC
 }
 
 func WithSlack(cfg SlackConfig) ServerOption {
@@ -78,7 +79,7 @@ func New(registry *model.WorkspaceRegistry, repo interfaces.Repository, authUC u
 	})
 
 	// API endpoints (auth required)
-	var notifier usecase.StatusChangeNotifier
+	var notifier usecase.TicketChangeNotifier
 	var slackUC *usecase.SlackUseCase
 	if s.slackCfg != nil {
 		notifier = s.slackCfg.Notifier
@@ -95,8 +96,8 @@ func New(registry *model.WorkspaceRegistry, repo interfaces.Repository, authUC u
 		s.mux.Route("/hooks/slack", func(r chi.Router) {
 			r.Use(slackSignatureMiddleware(s.slackCfg.SigningSecret))
 			r.Post("/event", slackEventHandler(s.slackCfg.SlackUC))
-			if s.slackCfg.TriageUC != nil {
-				r.Post("/interaction", slackInteractionsHandler(s.slackCfg.TriageUC))
+			if s.slackCfg.TriageUC != nil || s.slackCfg.QuickUC != nil {
+				r.Post("/interaction", slackInteractionsHandler(s.slackCfg.TriageUC, s.slackCfg.QuickUC))
 			}
 		})
 	}

--- a/pkg/controller/http/slack_interactions.go
+++ b/pkg/controller/http/slack_interactions.go
@@ -36,12 +36,21 @@ type TriageInteractionsUC interface {
 	HandleReviewReinvestigate(ctx context.Context, ticketID types.TicketID, channelID, messageTS, actorID string, state *slackgo.ViewState) error
 }
 
+// QuickActionsInteractionsUC is the surface needed to react to the
+// inline quick-actions menu (assignee + status selects). Resolution of
+// the underlying ticket happens inside the usecase via channel + thread
+// timestamp, so the handler does not touch the registry.
+type QuickActionsInteractionsUC interface {
+	HandleAssigneeChange(ctx context.Context, channelID, threadTS string, userIDs []string) error
+	HandleStatusChange(ctx context.Context, channelID, threadTS, statusID string) error
+}
+
 // slackInteractionsHandler handles Slack Block Kit interactivity callbacks
 // (block_actions / view_submission). Slack delivers these as
 // application/x-www-form-urlencoded with a single "payload" field carrying
 // the JSON. The signature middleware (shared with /event) has already
 // validated the request body bytes by the time we run.
-func slackInteractionsHandler(uc TriageInteractionsUC) http.HandlerFunc {
+func slackInteractionsHandler(triageUC TriageInteractionsUC, quickUC QuickActionsInteractionsUC) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 		logger := logging.From(ctx)
@@ -68,9 +77,9 @@ func slackInteractionsHandler(uc TriageInteractionsUC) http.HandlerFunc {
 
 		switch cb.Type {
 		case slackgo.InteractionTypeBlockActions:
-			handleBlockActions(ctx, w, uc, &cb)
+			handleBlockActions(ctx, w, triageUC, quickUC, &cb)
 		case slackgo.InteractionTypeViewSubmission:
-			handleViewSubmission(ctx, w, uc, &cb)
+			handleViewSubmission(ctx, w, triageUC, &cb)
 		default:
 			logger.Debug("slack interaction ignored: unsupported type",
 				slog.String("type", string(cb.Type)),
@@ -80,74 +89,119 @@ func slackInteractionsHandler(uc TriageInteractionsUC) http.HandlerFunc {
 	}
 }
 
-func handleBlockActions(ctx context.Context, w http.ResponseWriter, uc TriageInteractionsUC, cb *slackgo.InteractionCallback) {
+func handleBlockActions(ctx context.Context, w http.ResponseWriter, triageUC TriageInteractionsUC, quickUC QuickActionsInteractionsUC, cb *slackgo.InteractionCallback) {
 	logger := logging.From(ctx)
 
+	// Quick-actions selects (assignee / status) and triage buttons can in
+	// principle co-arrive in the same payload, though Slack's UI delivers
+	// at most one action per click. Iterate once, classify, and dispatch
+	// each match. Quick-actions resolve the underlying ticket from
+	// channel + thread_ts (the menu lives as a thread reply on the
+	// ticket's root message), so we forward those raw fields.
+	channelID := cb.Channel.ID
+	threadTS := cb.Message.ThreadTimestamp
+	if threadTS == "" {
+		threadTS = cb.Message.Timestamp
+	}
+
 	var triageAction *slackgo.BlockAction
+	var quickAssignee *slackgo.BlockAction
+	var quickStatus *slackgo.BlockAction
+
 	for i := range cb.ActionCallback.BlockActions {
-		id := cb.ActionCallback.BlockActions[i].ActionID
-		switch id {
+		ba := cb.ActionCallback.BlockActions[i]
+		switch ba.ActionID {
 		case slackService.TriageSubmitActionID,
 			slackService.TriageRetryActionID,
 			slackService.TriageReviewEditActionID,
 			slackService.TriageReviewSubmitActionID,
 			slackService.TriageReviewReinvestigateActionID:
-			triageAction = cb.ActionCallback.BlockActions[i]
-		}
-		if triageAction != nil {
-			break
+			if triageAction == nil {
+				triageAction = ba
+			}
+		case slackService.QuickActionsAssigneeActionID:
+			quickAssignee = ba
+		case slackService.QuickActionsStatusActionID:
+			quickStatus = ba
 		}
 	}
-	if triageAction == nil {
-		logger.Debug("slack interaction ignored: no triage action")
+
+	if triageAction == nil && quickAssignee == nil && quickStatus == nil {
+		logger.Debug("slack interaction ignored: no recognised action")
 		w.WriteHeader(http.StatusOK)
 		return
 	}
 
-	ticketID := types.TicketID(triageAction.Value)
-	channelID := cb.Channel.ID
-	messageTS := cb.Message.Timestamp
-	triggerID := cb.TriggerID
-	actionID := triageAction.ActionID
-	actorID := cb.User.ID
-	state := cb.BlockActionState
+	if triageAction != nil {
+		ticketID := types.TicketID(triageAction.Value)
+		messageTS := cb.Message.Timestamp
+		triggerID := cb.TriggerID
+		actionID := triageAction.ActionID
+		actorID := cb.User.ID
+		state := cb.BlockActionState
 
-	// Edit / Re-investigate must call OpenView synchronously to honor
-	// Slack's trigger_id deadline (~3s). Submit-style buttons follow the
-	// existing 200-then-async pattern.
-	switch actionID {
-	case slackService.TriageReviewEditActionID:
-		if err := uc.HandleReviewEditOpen(ctx, ticketID, channelID, messageTS, triggerID); err != nil {
-			errutil.Handle(ctx, goerr.Wrap(err, "review edit open"))
+		// Edit / Re-investigate must call OpenView synchronously to honor
+		// Slack's trigger_id deadline (~3s). Submit-style buttons follow
+		// the existing 200-then-async pattern.
+		switch actionID {
+		case slackService.TriageReviewEditActionID:
+			if err := triageUC.HandleReviewEditOpen(ctx, ticketID, channelID, messageTS, triggerID); err != nil {
+				errutil.Handle(ctx, goerr.Wrap(err, "review edit open"))
+			}
+			w.WriteHeader(http.StatusOK)
+			return
+		case slackService.TriageReviewReinvestigateActionID:
+			if err := triageUC.HandleReviewReinvestigateOpen(ctx, ticketID, channelID, messageTS, triggerID); err != nil {
+				errutil.Handle(ctx, goerr.Wrap(err, "review reinvestigate open"))
+			}
+			w.WriteHeader(http.StatusOK)
+			return
 		}
+
 		w.WriteHeader(http.StatusOK)
-		return
-	case slackService.TriageReviewReinvestigateActionID:
-		if err := uc.HandleReviewReinvestigateOpen(ctx, ticketID, channelID, messageTS, triggerID); err != nil {
-			errutil.Handle(ctx, goerr.Wrap(err, "review reinvestigate open"))
-		}
-		w.WriteHeader(http.StatusOK)
+
+		async.Dispatch(ctx, func(ctx context.Context) error {
+			switch actionID {
+			case slackService.TriageSubmitActionID:
+				return triageUC.HandleSubmit(ctx, triage.Submission{
+					TicketID:  ticketID,
+					ChannelID: channelID,
+					MessageTS: messageTS,
+					State:     state,
+				})
+			case slackService.TriageRetryActionID:
+				return triageUC.HandleRetry(ctx, ticketID, channelID, messageTS)
+			case slackService.TriageReviewSubmitActionID:
+				return triageUC.HandleReviewSubmit(ctx, ticketID, channelID, messageTS, actorID)
+			}
+			return nil
+		})
 		return
 	}
 
+	// Quick-actions path — ack first, then dispatch.
 	w.WriteHeader(http.StatusOK)
 
-	async.Dispatch(ctx, func(ctx context.Context) error {
-		switch actionID {
-		case slackService.TriageSubmitActionID:
-			return uc.HandleSubmit(ctx, triage.Submission{
-				TicketID:  ticketID,
-				ChannelID: channelID,
-				MessageTS: messageTS,
-				State:     state,
-			})
-		case slackService.TriageRetryActionID:
-			return uc.HandleRetry(ctx, ticketID, channelID, messageTS)
-		case slackService.TriageReviewSubmitActionID:
-			return uc.HandleReviewSubmit(ctx, ticketID, channelID, messageTS, actorID)
+	if quickUC == nil {
+		logger.Debug("quick action ignored: usecase not configured")
+		return
+	}
+
+	if quickAssignee != nil {
+		userIDs := append([]string(nil), quickAssignee.SelectedUsers...)
+		async.Dispatch(ctx, func(ctx context.Context) error {
+			return quickUC.HandleAssigneeChange(ctx, channelID, threadTS, userIDs)
+		})
+	}
+	if quickStatus != nil {
+		statusID := ""
+		if quickStatus.SelectedOption.Value != "" {
+			statusID = quickStatus.SelectedOption.Value
 		}
-		return nil
-	})
+		async.Dispatch(ctx, func(ctx context.Context) error {
+			return quickUC.HandleStatusChange(ctx, channelID, threadTS, statusID)
+		})
+	}
 }
 
 func handleViewSubmission(ctx context.Context, w http.ResponseWriter, uc TriageInteractionsUC, cb *slackgo.InteractionCallback) {

--- a/pkg/service/slack/quick_actions.go
+++ b/pkg/service/slack/quick_actions.go
@@ -1,0 +1,111 @@
+package slack
+
+import (
+	"context"
+
+	"github.com/m-mizutani/shepherd/pkg/domain/model/config"
+	"github.com/m-mizutani/shepherd/pkg/domain/types"
+	"github.com/m-mizutani/shepherd/pkg/utils/i18n"
+	slackgo "github.com/slack-go/slack"
+)
+
+// Quick-actions Slack identifiers. The action_id values are the contract
+// between the menu message and the HTTP interactions handler. The handler
+// resolves the underlying ticket from the message's channel_id + thread_ts
+// rather than from an embedded value, since the menu is always posted as
+// a thread reply on the ticket's root message.
+const (
+	QuickActionsAssigneeBlockID  = "quick_actions_assignee"
+	QuickActionsAssigneeActionID = "quick_actions_assignee_select"
+	QuickActionsStatusBlockID    = "quick_actions_status"
+	QuickActionsStatusActionID   = "quick_actions_status_select"
+)
+
+// QuickActionsTicketState bundles the bits of ticket state the menu
+// renderer needs to seed initial values, so callers populate it from a
+// *model.Ticket without pulling the full domain type into this layer.
+type QuickActionsTicketState struct {
+	StatusID    types.StatusID
+	AssigneeIDs []types.SlackUserID
+}
+
+// BuildQuickActionsBlocks renders the empty-mention quick-actions menu:
+// a ticket reference header, a section header, then two section blocks
+// each carrying a select element as their accessory — multi_users_select
+// for assignees, static_select for statuses. The blocks are placed in
+// the section accessory slot (rather than an actions block) so each
+// element gets its own block_id, which keeps the interactions handler
+// straightforward when the user only changes one of them at a time.
+func BuildQuickActionsBlocks(ctx context.Context, ref TicketRef, state QuickActionsTicketState, statuses []config.StatusDef) []slackgo.Block {
+	loc := i18n.From(ctx)
+
+	blocks := []slackgo.Block{}
+	if header := ticketRefBlock(ctx, ref, TicketRefStateActive); header != nil {
+		blocks = append(blocks, header)
+	}
+	blocks = append(blocks, slackgo.NewSectionBlock(
+		slackgo.NewTextBlockObject(slackgo.MarkdownType,
+			loc.T(i18n.MsgQuickActionsHeader), false, false),
+		nil, nil,
+	))
+
+	blocks = append(blocks, buildQuickActionsAssigneeBlock(ctx, state.AssigneeIDs))
+	blocks = append(blocks, buildQuickActionsStatusBlock(ctx, state.StatusID, statuses))
+
+	return blocks
+}
+
+func buildQuickActionsAssigneeBlock(ctx context.Context, assignees []types.SlackUserID) slackgo.Block {
+	loc := i18n.From(ctx)
+	placeholder := slackgo.NewTextBlockObject(slackgo.PlainTextType,
+		loc.T(i18n.MsgQuickActionsAssigneePlaceholder), false, false)
+	users := slackgo.NewOptionsMultiSelectBlockElement(slackgo.MultiOptTypeUser, placeholder, QuickActionsAssigneeActionID)
+	if len(assignees) > 0 {
+		initial := make([]string, 0, len(assignees))
+		for _, id := range assignees {
+			if id == "" {
+				continue
+			}
+			initial = append(initial, string(id))
+		}
+		users.InitialUsers = initial
+	}
+	block := slackgo.NewSectionBlock(
+		slackgo.NewTextBlockObject(slackgo.MarkdownType,
+			"*"+loc.T(i18n.MsgQuickActionsAssigneeLabel)+"*", false, false),
+		nil,
+		slackgo.NewAccessory(users),
+	)
+	block.BlockID = QuickActionsAssigneeBlockID
+	return block
+}
+
+func buildQuickActionsStatusBlock(ctx context.Context, statusID types.StatusID, statuses []config.StatusDef) slackgo.Block {
+	loc := i18n.From(ctx)
+	placeholder := slackgo.NewTextBlockObject(slackgo.PlainTextType,
+		loc.T(i18n.MsgQuickActionsStatusPlaceholder), false, false)
+
+	options := make([]*slackgo.OptionBlockObject, 0, len(statuses))
+	for _, s := range statuses {
+		options = append(options, slackgo.NewOptionBlockObject(
+			string(s.ID),
+			slackgo.NewTextBlockObject(slackgo.PlainTextType, s.Name, false, false),
+			nil,
+		))
+	}
+	sel := slackgo.NewOptionsSelectBlockElement(slackgo.OptTypeStatic, placeholder, QuickActionsStatusActionID, options...)
+	for _, opt := range options {
+		if opt.Value == string(statusID) {
+			sel = sel.WithInitialOption(opt)
+			break
+		}
+	}
+	block := slackgo.NewSectionBlock(
+		slackgo.NewTextBlockObject(slackgo.MarkdownType,
+			"*"+loc.T(i18n.MsgQuickActionsStatusLabel)+"*", false, false),
+		nil,
+		slackgo.NewAccessory(sel),
+	)
+	block.BlockID = QuickActionsStatusBlockID
+	return block
+}

--- a/pkg/service/slack/quick_actions_test.go
+++ b/pkg/service/slack/quick_actions_test.go
@@ -1,0 +1,64 @@
+package slack_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/m-mizutani/gt"
+	"github.com/m-mizutani/shepherd/pkg/domain/model/config"
+	"github.com/m-mizutani/shepherd/pkg/domain/types"
+	slackService "github.com/m-mizutani/shepherd/pkg/service/slack"
+	slackgo "github.com/slack-go/slack"
+)
+
+func TestBuildQuickActionsBlocks_PreselectsCurrentValues(t *testing.T) {
+	ref := slackService.TicketRef{
+		ID:     "tkt-1",
+		SeqNum: 42,
+		Title:  "Login fails on staging",
+		URL:    "https://example.test/t/42",
+	}
+	state := slackService.QuickActionsTicketState{
+		StatusID:    "in-progress",
+		AssigneeIDs: []types.SlackUserID{"U111", "U222"},
+	}
+	statuses := []config.StatusDef{
+		{ID: "open", Name: "Open"},
+		{ID: "in-progress", Name: "In Progress"},
+		{ID: "resolved", Name: "Resolved"},
+	}
+
+	blocks := slackService.BuildQuickActionsBlocks(context.Background(), ref, state, statuses)
+	// Header (ticket ref) + section header + assignee block + status block.
+	gt.A(t, blocks).Length(4)
+
+	assigneeBlock, ok := blocks[2].(*slackgo.SectionBlock)
+	gt.V(t, ok).Equal(true)
+	gt.S(t, assigneeBlock.BlockID).Equal(slackService.QuickActionsAssigneeBlockID)
+	users := assigneeBlock.Accessory.MultiSelectElement
+	gt.V(t, users == nil).Equal(false)
+	gt.S(t, users.ActionID).Equal(slackService.QuickActionsAssigneeActionID)
+	gt.A(t, users.InitialUsers).Length(2)
+	gt.S(t, users.InitialUsers[0]).Equal("U111")
+
+	statusBlock, ok := blocks[3].(*slackgo.SectionBlock)
+	gt.V(t, ok).Equal(true)
+	gt.S(t, statusBlock.BlockID).Equal(slackService.QuickActionsStatusBlockID)
+	sel := statusBlock.Accessory.SelectElement
+	gt.V(t, sel == nil).Equal(false)
+	gt.S(t, sel.ActionID).Equal(slackService.QuickActionsStatusActionID)
+	gt.V(t, sel.InitialOption.Value).Equal("in-progress")
+}
+
+func TestBuildQuickActionsBlocks_NoAssignees_NoInitialUsers(t *testing.T) {
+	ref := slackService.TicketRef{ID: "tkt-1", SeqNum: 1, Title: "T", URL: "https://x.test/1"}
+	state := slackService.QuickActionsTicketState{StatusID: "open"}
+	statuses := []config.StatusDef{{ID: "open", Name: "Open"}}
+
+	blocks := slackService.BuildQuickActionsBlocks(context.Background(), ref, state, statuses)
+	gt.A(t, blocks).Longer(2)
+
+	assigneeBlock := blocks[2].(*slackgo.SectionBlock)
+	users := assigneeBlock.Accessory.MultiSelectElement
+	gt.A(t, users.InitialUsers).Length(0)
+}

--- a/pkg/service/slack/slack.go
+++ b/pkg/service/slack/slack.go
@@ -201,26 +201,6 @@ func (c *Client) ReplyTicketCreated(ctx context.Context, channelID, threadTS str
 	return c.ReplyThread(ctx, channelID, threadTS, text)
 }
 
-func (c *Client) ReplyStatusChange(ctx context.Context, channelID, threadTS, oldStatusName, newStatusName string) error {
-	text := i18n.From(ctx).T(i18n.MsgStatusChange, "old", oldStatusName, "new", newStatusName)
-	_, _, err := c.api.PostMessageContext(ctx, channelID,
-		slackgo.MsgOptionTS(threadTS),
-		slackgo.MsgOptionBlocks(
-			slackgo.NewContextBlock("",
-				slackgo.NewTextBlockObject("mrkdwn", text, false, false),
-			),
-		),
-	)
-	if err != nil {
-		return goerr.Wrap(err, "failed to post status change notification",
-			goerr.V("channel_id", channelID),
-			goerr.V("thread_ts", threadTS),
-			goerr.Tag(errutil.TagSlackError),
-		)
-	}
-	return nil
-}
-
 // Message is a minimal representation of a Slack message used by tools and
 // downstream consumers. It hides the noisy slack-go Message struct behind a
 // small surface of fields that LLMs actually care about.

--- a/pkg/service/slack/ticket_change.go
+++ b/pkg/service/slack/ticket_change.go
@@ -1,0 +1,89 @@
+package slack
+
+import (
+	"context"
+	"strings"
+
+	"github.com/m-mizutani/goerr/v2"
+	"github.com/m-mizutani/shepherd/pkg/utils/errutil"
+	"github.com/m-mizutani/shepherd/pkg/utils/i18n"
+	slackgo "github.com/slack-go/slack"
+)
+
+// TicketChange describes a mutation that should be reflected back to the
+// originating Slack thread as a single context-block notification. Either
+// the status block, the assignee block, or both, may be set on a given
+// payload — when both are set, the notifier renders them in one message
+// so the thread reader sees one event per logical update rather than two.
+type TicketChange struct {
+	StatusChanged   bool
+	OldStatusName   string
+	NewStatusName   string
+	AssigneeChanged bool
+	OldAssigneeIDs  []string
+	NewAssigneeIDs  []string
+}
+
+// NotifyTicketChange posts a context-block message summarising a status
+// and/or assignee transition. It is a no-op when neither block is set,
+// since callers gate on this themselves but the safety net keeps the
+// helper composable.
+func (c *Client) NotifyTicketChange(ctx context.Context, channelID, threadTS string, change TicketChange) error {
+	if !change.StatusChanged && !change.AssigneeChanged {
+		return nil
+	}
+	loc := i18n.From(ctx)
+
+	lines := make([]string, 0, 2)
+	if change.StatusChanged {
+		lines = append(lines, loc.T(i18n.MsgStatusChange,
+			"old", change.OldStatusName,
+			"new", change.NewStatusName,
+		))
+	}
+	if change.AssigneeChanged {
+		lines = append(lines, loc.T(i18n.MsgAssigneeChange,
+			"old", renderAssignees(ctx, change.OldAssigneeIDs),
+			"new", renderAssignees(ctx, change.NewAssigneeIDs),
+		))
+	}
+	text := strings.Join(lines, "\n")
+
+	_, _, err := c.api.PostMessageContext(ctx, channelID,
+		slackgo.MsgOptionTS(threadTS),
+		slackgo.MsgOptionBlocks(
+			slackgo.NewContextBlock("",
+				slackgo.NewTextBlockObject("mrkdwn", text, false, false),
+			),
+		),
+	)
+	if err != nil {
+		return goerr.Wrap(err, "failed to post ticket change notification",
+			goerr.V("channel_id", channelID),
+			goerr.V("thread_ts", threadTS),
+			goerr.Tag(errutil.TagSlackError),
+		)
+	}
+	return nil
+}
+
+// renderAssignees produces the mrkdwn fragment that represents an
+// assignee list for the change notification. An empty list collapses to
+// the localised "(unassigned)" marker so the transition stays readable
+// even when one side is empty.
+func renderAssignees(ctx context.Context, ids []string) string {
+	if len(ids) == 0 {
+		return i18n.From(ctx).T(i18n.MsgUnassigned)
+	}
+	mentions := make([]string, 0, len(ids))
+	for _, id := range ids {
+		if id == "" {
+			continue
+		}
+		mentions = append(mentions, "<@"+id+">")
+	}
+	if len(mentions) == 0 {
+		return i18n.From(ctx).T(i18n.MsgUnassigned)
+	}
+	return strings.Join(mentions, " ")
+}

--- a/pkg/usecase/quick_actions.go
+++ b/pkg/usecase/quick_actions.go
@@ -1,0 +1,122 @@
+package usecase
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/m-mizutani/goerr/v2"
+	"github.com/m-mizutani/shepherd/pkg/domain/interfaces"
+	"github.com/m-mizutani/shepherd/pkg/domain/model"
+	"github.com/m-mizutani/shepherd/pkg/domain/types"
+	"github.com/m-mizutani/shepherd/pkg/utils/logging"
+)
+
+// QuickActionsUseCase orchestrates the inline assignee / status changes a
+// user makes through the Slack quick-actions menu. It resolves the
+// underlying ticket from channel + thread_ts (the menu is always posted
+// as a thread reply, so block_actions carry the ticket's thread_ts in
+// their cb.Message.ThreadTimestamp), then funnels the mutation through
+// the same TicketUseCase.Update entry point used by the HTTP API. That
+// guarantees the change-notification path fires once per logical update,
+// regardless of which surface drove it.
+type QuickActionsUseCase struct {
+	repo     interfaces.Repository
+	registry *model.WorkspaceRegistry
+	ticketUC *TicketUseCase
+}
+
+func NewQuickActionsUseCase(repo interfaces.Repository, registry *model.WorkspaceRegistry, ticketUC *TicketUseCase) *QuickActionsUseCase {
+	return &QuickActionsUseCase{
+		repo:     repo,
+		registry: registry,
+		ticketUC: ticketUC,
+	}
+}
+
+// HandleAssigneeChange applies the user's multi_users_select choice to
+// the ticket identified by (channelID, threadTS). userIDs may be empty
+// when the user cleared the field. Unmapped channels / unknown threads
+// are debug-logged no-ops so re-deliveries from Slack do not error.
+func (uc *QuickActionsUseCase) HandleAssigneeChange(ctx context.Context, channelID, threadTS string, userIDs []string) error {
+	ticket, wsID, ok, err := uc.resolveTicket(ctx, channelID, threadTS)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return nil
+	}
+
+	assignees := make([]types.SlackUserID, 0, len(userIDs))
+	for _, id := range userIDs {
+		if id == "" {
+			continue
+		}
+		assignees = append(assignees, types.SlackUserID(id))
+	}
+
+	if _, err := uc.ticketUC.Update(ctx, wsID, ticket.ID, nil, nil, nil, &assignees, nil); err != nil {
+		return goerr.Wrap(err, "failed to update assignees from quick actions",
+			goerr.V("ticket_id", string(ticket.ID)),
+		)
+	}
+	return nil
+}
+
+// HandleStatusChange applies the user's static_select choice to the
+// ticket identified by (channelID, threadTS). statusID == "" is treated
+// as "no change" (defensive — Slack usually never delivers an empty
+// option from a non-optional select). Unmapped channels / unknown
+// threads are debug-logged no-ops.
+func (uc *QuickActionsUseCase) HandleStatusChange(ctx context.Context, channelID, threadTS, statusID string) error {
+	if statusID == "" {
+		return nil
+	}
+	ticket, wsID, ok, err := uc.resolveTicket(ctx, channelID, threadTS)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return nil
+	}
+
+	sid := types.StatusID(statusID)
+	if _, err := uc.ticketUC.Update(ctx, wsID, ticket.ID, nil, nil, &sid, nil, nil); err != nil {
+		return goerr.Wrap(err, "failed to update status from quick actions",
+			goerr.V("ticket_id", string(ticket.ID)),
+		)
+	}
+	return nil
+}
+
+// resolveTicket maps channelID + threadTS to the underlying ticket via
+// the workspace registry. When the channel is unmapped or no ticket
+// exists for the thread, ok==false and the caller should treat the call
+// as a no-op (re-delivered or stale block_actions).
+func (uc *QuickActionsUseCase) resolveTicket(ctx context.Context, channelID, threadTS string) (*model.Ticket, types.WorkspaceID, bool, error) {
+	logger := logging.From(ctx)
+
+	entry, ok := uc.registry.GetBySlackChannelID(channelID)
+	if !ok {
+		logger.Debug("quick action ignored: channel not mapped",
+			slog.String("channel_id", channelID),
+		)
+		return nil, "", false, nil
+	}
+	wsID := entry.Workspace.ID
+
+	ticket, err := uc.repo.Ticket().GetBySlackThreadTS(ctx, wsID, types.SlackChannelID(channelID), types.SlackThreadTS(threadTS))
+	if err != nil {
+		return nil, wsID, false, goerr.Wrap(err, "failed to find ticket for quick action",
+			goerr.V("channel_id", channelID),
+			goerr.V("thread_ts", threadTS),
+		)
+	}
+	if ticket == nil {
+		logger.Debug("quick action ignored: no ticket for thread",
+			slog.String("channel_id", channelID),
+			slog.String("thread_ts", threadTS),
+		)
+		return nil, wsID, false, nil
+	}
+	return ticket, wsID, true, nil
+}

--- a/pkg/usecase/quick_actions_test.go
+++ b/pkg/usecase/quick_actions_test.go
@@ -1,0 +1,131 @@
+package usecase_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/m-mizutani/gt"
+	"github.com/m-mizutani/shepherd/pkg/domain/model"
+	"github.com/m-mizutani/shepherd/pkg/domain/model/config"
+	"github.com/m-mizutani/shepherd/pkg/domain/types"
+	"github.com/m-mizutani/shepherd/pkg/repository/memory"
+	"github.com/m-mizutani/shepherd/pkg/usecase"
+)
+
+func setupQuickActionsRig(t *testing.T) (*usecase.QuickActionsUseCase, *memory.Repository, *fakeTicketChangeNotifier) {
+	t.Helper()
+	repo := memory.New()
+	t.Cleanup(func() { _ = repo.Close() })
+
+	registry := model.NewWorkspaceRegistry()
+	registry.Register(&model.WorkspaceEntry{
+		Workspace: model.Workspace{ID: "ws-test", Name: "Test"},
+		FieldSchema: &config.FieldSchema{
+			Statuses: []config.StatusDef{
+				{ID: "open", Name: "Open"},
+				{ID: "in-progress", Name: "In Progress"},
+				{ID: "resolved", Name: "Resolved"},
+			},
+			TicketConfig: config.TicketConfig{
+				DefaultStatusID: "open",
+			},
+		},
+		SlackChannelID: "C-quick",
+	})
+
+	notifier := &fakeTicketChangeNotifier{}
+	ticketUC := usecase.NewTicketUseCase(repo, registry, notifier)
+	uc := usecase.NewQuickActionsUseCase(repo, registry, ticketUC)
+	return uc, repo, notifier
+}
+
+func plantQuickTicket(t *testing.T, repo *memory.Repository, threadTS string, assignees []types.SlackUserID, statusID types.StatusID) *model.Ticket {
+	t.Helper()
+	ctx := context.Background()
+	ticket := &model.Ticket{
+		ID:             "tkt-q",
+		WorkspaceID:    "ws-test",
+		Title:          "T",
+		StatusID:       statusID,
+		AssigneeIDs:    assignees,
+		SlackChannelID: "C-quick",
+		SlackThreadTS:  types.SlackThreadTS(threadTS),
+	}
+	created := gt.R1(repo.Ticket().Create(ctx, "ws-test", ticket)).NoError(t)
+	return created
+}
+
+func TestQuickActionsUseCase_HandleStatusChange_UpdatesAndNotifies(t *testing.T) {
+	uc, repo, notifier := setupQuickActionsRig(t)
+	plantQuickTicket(t, repo, "100.000", nil, "open")
+
+	ctx := context.Background()
+	gt.NoError(t, uc.HandleStatusChange(ctx, "C-quick", "100.000", "in-progress"))
+
+	got := gt.R1(repo.Ticket().Get(ctx, "ws-test", "tkt-q")).NoError(t)
+	gt.S(t, string(got.StatusID)).Equal("in-progress")
+
+	gt.A(t, notifier.calls).Length(1)
+	gt.V(t, notifier.calls[0].change.StatusChanged).Equal(true)
+	gt.V(t, notifier.calls[0].change.AssigneeChanged).Equal(false)
+}
+
+func TestQuickActionsUseCase_HandleAssigneeChange_UpdatesAndNotifies(t *testing.T) {
+	uc, repo, notifier := setupQuickActionsRig(t)
+	plantQuickTicket(t, repo, "200.000", nil, "open")
+
+	ctx := context.Background()
+	gt.NoError(t, uc.HandleAssigneeChange(ctx, "C-quick", "200.000", []string{"U-alice", "U-bob"}))
+
+	got := gt.R1(repo.Ticket().Get(ctx, "ws-test", "tkt-q")).NoError(t)
+	gt.A(t, got.AssigneeIDs).Length(2)
+
+	gt.A(t, notifier.calls).Length(1)
+	gt.V(t, notifier.calls[0].change.AssigneeChanged).Equal(true)
+	gt.A(t, notifier.calls[0].change.NewAssigneeIDs).Length(2)
+}
+
+func TestQuickActionsUseCase_HandleAssigneeChange_ClearAssignees(t *testing.T) {
+	uc, repo, notifier := setupQuickActionsRig(t)
+	plantQuickTicket(t, repo, "300.000", []types.SlackUserID{"U-prev"}, "open")
+
+	ctx := context.Background()
+	gt.NoError(t, uc.HandleAssigneeChange(ctx, "C-quick", "300.000", []string{}))
+
+	got := gt.R1(repo.Ticket().Get(ctx, "ws-test", "tkt-q")).NoError(t)
+	gt.A(t, got.AssigneeIDs).Length(0)
+
+	gt.A(t, notifier.calls).Length(1)
+	gt.A(t, notifier.calls[0].change.OldAssigneeIDs).Length(1)
+	gt.A(t, notifier.calls[0].change.NewAssigneeIDs).Length(0)
+}
+
+func TestQuickActionsUseCase_HandleStatusChange_NoChange_NoNotify(t *testing.T) {
+	uc, repo, notifier := setupQuickActionsRig(t)
+	plantQuickTicket(t, repo, "400.000", nil, "open")
+
+	ctx := context.Background()
+	gt.NoError(t, uc.HandleStatusChange(ctx, "C-quick", "400.000", "open"))
+
+	gt.A(t, notifier.calls).Length(0)
+}
+
+func TestQuickActionsUseCase_UnknownChannel_Noop(t *testing.T) {
+	uc, _, notifier := setupQuickActionsRig(t)
+
+	ctx := context.Background()
+	gt.NoError(t, uc.HandleStatusChange(ctx, "C-not-mapped", "100.000", "open"))
+	gt.NoError(t, uc.HandleAssigneeChange(ctx, "C-not-mapped", "100.000", []string{"U-x"}))
+
+	gt.A(t, notifier.calls).Length(0)
+}
+
+func TestQuickActionsUseCase_UnknownThread_Noop(t *testing.T) {
+	uc, _, notifier := setupQuickActionsRig(t)
+
+	ctx := context.Background()
+	gt.NoError(t, uc.HandleStatusChange(ctx, "C-quick", "999.999", "open"))
+	gt.NoError(t, uc.HandleAssigneeChange(ctx, "C-quick", "999.999", []string{"U-x"}))
+
+	gt.A(t, notifier.calls).Length(0)
+}

--- a/pkg/usecase/slack.go
+++ b/pkg/usecase/slack.go
@@ -20,6 +20,7 @@ import (
 	"github.com/m-mizutani/shepherd/pkg/usecase/prompt"
 	"github.com/m-mizutani/shepherd/pkg/utils/errutil"
 	"github.com/m-mizutani/shepherd/pkg/utils/logging"
+	slackgo "github.com/slack-go/slack"
 )
 
 // SlackClient captures the subset of the Slack service the usecase depends on.
@@ -27,6 +28,7 @@ import (
 type SlackClient interface {
 	ReplyThread(ctx context.Context, channelID, threadTS, text string) error
 	ReplyTicketCreated(ctx context.Context, channelID, threadTS string, seqNum int64, ticketURL string) error
+	PostThreadBlocks(ctx context.Context, channelID, threadTS string, blocks []slackgo.Block) (string, error)
 	GetUserInfo(ctx context.Context, userID string) (*slackService.UserInfo, error)
 	ListUsers(ctx context.Context) ([]*slackService.UserInfo, error)
 }
@@ -214,19 +216,19 @@ func (uc *SlackUseCase) HandleThreadReply(ctx context.Context, channelID, thread
 	return nil
 }
 
-// HandleAppMention responds to an app_mention event by feeding the ticket
-// thread context to the configured LLM and posting the reply back to Slack.
-// When the LLM is not configured, or when the mentioned thread does not map to
-// a known ticket, the call is a debug-logged no-op.
+// HandleAppMention responds to an app_mention event. Two flavours are
+// handled:
+//   - empty mention (no body text after the bot's <@…> token): post a
+//     quick-actions menu so the user can flip the ticket's status or
+//     assignee inline. Works regardless of whether an LLM is configured.
+//   - non-empty mention: feed the ticket thread context to the configured
+//     LLM and post the reply back to Slack. When the LLM is not
+//     configured, this branch is a debug-logged no-op.
+//
+// In both cases, when the mentioned thread does not map to a known
+// ticket, the call is a debug-logged no-op.
 func (uc *SlackUseCase) HandleAppMention(ctx context.Context, channelID, userID, text, messageTS, threadTS string) error {
 	logger := logging.From(ctx)
-
-	if uc.llm == nil {
-		logger.Debug("app_mention ignored: LLM not configured",
-			slog.String("channel_id", channelID),
-		)
-		return nil
-	}
 
 	rootTS := threadTS
 	if rootTS == "" {
@@ -254,6 +256,18 @@ func (uc *SlackUseCase) HandleAppMention(ctx context.Context, channelID, userID,
 		return nil
 	}
 
+	body := stripMentionTokens(text)
+	if body == "" {
+		return uc.postQuickActionsMenu(ctx, entry, ticket, rootTS)
+	}
+
+	if uc.llm == nil {
+		logger.Debug("app_mention ignored: LLM not configured",
+			slog.String("channel_id", channelID),
+		)
+		return nil
+	}
+
 	comments, err := uc.repo.Comment().List(ctx, wsID, ticket.ID)
 	if err != nil {
 		return goerr.Wrap(err, "failed to list comments for app_mention")
@@ -271,7 +285,7 @@ func (uc *SlackUseCase) HandleAppMention(ctx context.Context, channelID, userID,
 	mentionAuthor := uc.resolveDisplayName(ctx, userID)
 	userPrompt, err := prompt.RenderMention(prompt.MentionInput{
 		MentionAuthor: mentionAuthor,
-		Mention:       stripMentionTokens(text),
+		Mention:       body,
 	})
 	if err != nil {
 		return goerr.Wrap(err, "failed to render mention prompt")
@@ -335,6 +349,31 @@ func (uc *SlackUseCase) HandleAppMention(ctx context.Context, channelID, userID,
 		slog.String("ticket_id", string(ticket.ID)),
 		slog.String("channel_id", channelID),
 	)
+	return nil
+}
+
+// postQuickActionsMenu builds and posts the empty-mention Quick Actions
+// menu (assignee multi-select + status select) into the ticket's thread.
+// The thread_ts of the posted message equals rootTS, so a subsequent
+// block_actions payload from the menu carries the same thread_ts and the
+// interactions handler can resolve back to the same ticket.
+func (uc *SlackUseCase) postQuickActionsMenu(ctx context.Context, entry *model.WorkspaceEntry, ticket *model.Ticket, rootTS string) error {
+	tURL, _ := url.JoinPath(uc.baseURL, "ws", string(entry.Workspace.ID), "tickets", string(ticket.ID))
+	ref := slackService.TicketRef{
+		ID:     ticket.ID,
+		SeqNum: ticket.SeqNum,
+		Title:  ticket.Title,
+		URL:    tURL,
+	}
+	state := slackService.QuickActionsTicketState{
+		StatusID:    ticket.StatusID,
+		AssigneeIDs: append([]types.SlackUserID(nil), ticket.AssigneeIDs...),
+	}
+	statuses := entry.FieldSchema.Statuses
+	blocks := slackService.BuildQuickActionsBlocks(ctx, ref, state, statuses)
+	if _, err := uc.slack.PostThreadBlocks(ctx, string(ticket.SlackChannelID), rootTS, blocks); err != nil {
+		return goerr.Wrap(err, "failed to post quick actions menu")
+	}
 	return nil
 }
 

--- a/pkg/usecase/slack_test.go
+++ b/pkg/usecase/slack_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/m-mizutani/shepherd/pkg/repository/memory"
 	slackService "github.com/m-mizutani/shepherd/pkg/service/slack"
 	"github.com/m-mizutani/shepherd/pkg/usecase"
+	slackgo "github.com/slack-go/slack"
 )
 
 const (
@@ -29,7 +30,14 @@ type fakeSlackClient struct {
 	mu             sync.Mutex
 	threadReplies  []threadReplyCall
 	ticketCreated  []ticketCreatedCall
+	threadBlocks   []threadBlocksCall
 	usersByID      map[string]*slackService.UserInfo
+}
+
+type threadBlocksCall struct {
+	channelID string
+	threadTS  string
+	blocks    []slackgo.Block
 }
 
 type threadReplyCall struct {
@@ -57,6 +65,13 @@ func (f *fakeSlackClient) ReplyTicketCreated(_ context.Context, channelID, threa
 	defer f.mu.Unlock()
 	f.ticketCreated = append(f.ticketCreated, ticketCreatedCall{channelID, threadTS, seqNum, ticketURL})
 	return nil
+}
+
+func (f *fakeSlackClient) PostThreadBlocks(_ context.Context, channelID, threadTS string, blocks []slackgo.Block) (string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.threadBlocks = append(f.threadBlocks, threadBlocksCall{channelID, threadTS, blocks})
+	return "ts-" + threadTS, nil
 }
 
 func (f *fakeSlackClient) GetUserInfo(_ context.Context, userID string) (*slackService.UserInfo, error) {
@@ -269,4 +284,68 @@ func containsMentionToken(s string) bool {
 		}
 	}
 	return false
+}
+
+// seedQuickActionsTicket plants a triaged ticket already bound to the
+// test channel + thread so HandleAppMention's empty-mention branch has
+// a real ticket to resolve. Done through the repo (not Create) so the
+// quick-actions test is decoupled from the ticket-creation flow.
+func seedQuickActionsTicket(t *testing.T, repo *memory.Repository, channelID, threadTS string, assignees []types.SlackUserID) *model.Ticket {
+	t.Helper()
+	ctx := context.Background()
+	ticket := &model.Ticket{
+		ID:             "tkt-quick",
+		WorkspaceID:    testWS,
+		Title:          "Title",
+		StatusID:       "open",
+		AssigneeIDs:    assignees,
+		SlackChannelID: types.SlackChannelID(channelID),
+		SlackThreadTS:  types.SlackThreadTS(threadTS),
+	}
+	created := gt.R1(repo.Ticket().Create(ctx, testWS, ticket)).NoError(t)
+	return created
+}
+
+func TestSlackUseCase_HandleAppMention_EmptyMention_PostsQuickActions(t *testing.T) {
+	// LLM mock fails the test if invoked — empty mention must NOT touch the LLM.
+	llm := &mock.LLMClientMock{
+		NewSessionFunc: func(_ context.Context, _ ...gollem.SessionOption) (gollem.Session, error) {
+			t.Fatalf("LLM must not be invoked for empty mentions")
+			return nil, nil
+		},
+	}
+	uc, slack, repo, _, _ := newSlackTestRig(t, llm)
+	seedQuickActionsTicket(t, repo, testChannel, "500.000", []types.SlackUserID{"U-pre"})
+
+	gt.NoError(t, uc.HandleAppMention(context.Background(), testChannel, "U1", "<@UBOT>   ", "500.001", "500.000"))
+
+	gt.A(t, slack.threadReplies).Length(0)
+	gt.A(t, slack.threadBlocks).Length(1)
+	call := slack.threadBlocks[0]
+	gt.S(t, call.channelID).Equal(testChannel)
+	gt.S(t, call.threadTS).Equal("500.000")
+	// Header (ticket ref) + section header + assignee + status = 4 blocks.
+	gt.A(t, call.blocks).Length(4)
+}
+
+func TestSlackUseCase_HandleAppMention_EmptyMention_NoLLMRequired(t *testing.T) {
+	// LLM is nil — the empty-mention branch must still post Quick Actions.
+	uc, slack, repo, _, _ := newSlackTestRig(t, nil)
+	seedQuickActionsTicket(t, repo, testChannel, "600.000", nil)
+
+	gt.NoError(t, uc.HandleAppMention(context.Background(), testChannel, "U1", "<@UBOT>", "600.001", "600.000"))
+
+	gt.A(t, slack.threadBlocks).Length(1)
+}
+
+func TestSlackUseCase_HandleAppMention_NonEmpty_DoesNotPostQuickActions(t *testing.T) {
+	// Non-empty mention with LLM nil should be a no-op (existing contract);
+	// crucially, it must not post Quick Actions.
+	uc, slack, repo, _, _ := newSlackTestRig(t, nil)
+	seedQuickActionsTicket(t, repo, testChannel, "700.000", nil)
+
+	gt.NoError(t, uc.HandleAppMention(context.Background(), testChannel, "U1", "<@UBOT> please help", "700.001", "700.000"))
+
+	gt.A(t, slack.threadBlocks).Length(0)
+	gt.A(t, slack.threadReplies).Length(0)
 }

--- a/pkg/usecase/ticket.go
+++ b/pkg/usecase/ticket.go
@@ -11,21 +11,26 @@ import (
 	"github.com/m-mizutani/shepherd/pkg/domain/model"
 	"github.com/m-mizutani/shepherd/pkg/domain/model/auth"
 	"github.com/m-mizutani/shepherd/pkg/domain/types"
+	slackService "github.com/m-mizutani/shepherd/pkg/service/slack"
 	"github.com/m-mizutani/shepherd/pkg/utils/errutil"
 	"github.com/m-mizutani/shepherd/pkg/utils/logging"
 )
 
-type StatusChangeNotifier interface {
-	ReplyStatusChange(ctx context.Context, channelID, threadTS, oldStatusName, newStatusName string) error
+// TicketChangeNotifier delivers a context-block notification about a ticket
+// mutation back to the originating Slack thread. Implementations are
+// responsible for rendering both status and assignee blocks in a single
+// message when both are present in the TicketChange payload.
+type TicketChangeNotifier interface {
+	NotifyTicketChange(ctx context.Context, channelID, threadTS string, change slackService.TicketChange) error
 }
 
 type TicketUseCase struct {
 	repo     interfaces.Repository
 	registry *model.WorkspaceRegistry
-	notifier StatusChangeNotifier
+	notifier TicketChangeNotifier
 }
 
-func NewTicketUseCase(repo interfaces.Repository, registry *model.WorkspaceRegistry, notifier StatusChangeNotifier) *TicketUseCase {
+func NewTicketUseCase(repo interfaces.Repository, registry *model.WorkspaceRegistry, notifier TicketChangeNotifier) *TicketUseCase {
 	return &TicketUseCase{
 		repo:     repo,
 		registry: registry,
@@ -113,6 +118,7 @@ func (uc *TicketUseCase) Update(ctx context.Context, workspaceID types.Workspace
 	}
 
 	oldStatusID := existing.StatusID
+	oldAssigneeIDs := append([]types.SlackUserID(nil), existing.AssigneeIDs...)
 
 	if title != nil {
 		existing.Title = *title
@@ -141,7 +147,10 @@ func (uc *TicketUseCase) Update(ctx context.Context, workspaceID types.Workspace
 		return nil, goerr.Wrap(err, "failed to update ticket")
 	}
 
-	if oldStatusID != updated.StatusID {
+	statusChanged := oldStatusID != updated.StatusID
+	assigneeChanged := !sameSlackUserIDSet(oldAssigneeIDs, updated.AssigneeIDs)
+
+	if statusChanged {
 		changedBy := changedByFromContext(ctx)
 		history := &model.TicketHistory{
 			ID:          uuid.Must(uuid.NewV7()).String(),
@@ -154,14 +163,16 @@ func (uc *TicketUseCase) Update(ctx context.Context, workspaceID types.Workspace
 		if _, err := uc.repo.TicketHistory().Create(ctx, workspaceID, ticketID, history); err != nil {
 			errutil.Handle(ctx, goerr.Wrap(err, "failed to create ticket history"))
 		}
+	}
 
-		uc.notifyStatusChange(ctx, workspaceID, updated, oldStatusID)
+	if statusChanged || assigneeChanged {
+		uc.notifyTicketChange(ctx, workspaceID, updated, oldStatusID, oldAssigneeIDs, statusChanged, assigneeChanged)
 	}
 
 	return updated, nil
 }
 
-func (uc *TicketUseCase) notifyStatusChange(ctx context.Context, workspaceID types.WorkspaceID, ticket *model.Ticket, oldStatusID types.StatusID) {
+func (uc *TicketUseCase) notifyTicketChange(ctx context.Context, workspaceID types.WorkspaceID, ticket *model.Ticket, oldStatusID types.StatusID, oldAssigneeIDs []types.SlackUserID, statusChanged, assigneeChanged bool) {
 	if uc.notifier == nil || ticket.SlackChannelID == "" || ticket.SlackThreadTS == "" {
 		return
 	}
@@ -171,16 +182,54 @@ func (uc *TicketUseCase) notifyStatusChange(ctx context.Context, workspaceID typ
 		return
 	}
 
-	oldName := statusName(entry, oldStatusID)
-	newName := statusName(entry, ticket.StatusID)
+	change := slackService.TicketChange{
+		StatusChanged:   statusChanged,
+		AssigneeChanged: assigneeChanged,
+	}
+	if statusChanged {
+		change.OldStatusName = statusName(entry, oldStatusID)
+		change.NewStatusName = statusName(entry, ticket.StatusID)
+	}
+	if assigneeChanged {
+		change.OldAssigneeIDs = toUserIDStrings(oldAssigneeIDs)
+		change.NewAssigneeIDs = toUserIDStrings(ticket.AssigneeIDs)
+	}
 
 	logger := logging.From(ctx)
-	if err := uc.notifier.ReplyStatusChange(ctx, string(ticket.SlackChannelID), string(ticket.SlackThreadTS), oldName, newName); err != nil {
-		logger.Warn("failed to notify status change to slack",
+	if err := uc.notifier.NotifyTicketChange(ctx, string(ticket.SlackChannelID), string(ticket.SlackThreadTS), change); err != nil {
+		logger.Warn("failed to notify ticket change to slack",
 			slog.String("ticket_id", string(ticket.ID)),
 			slog.Any("error", err),
 		)
 	}
+}
+
+func toUserIDStrings(ids []types.SlackUserID) []string {
+	out := make([]string, 0, len(ids))
+	for _, id := range ids {
+		out = append(out, string(id))
+	}
+	return out
+}
+
+// sameSlackUserIDSet treats assignee lists as unordered sets — order in
+// AssigneeIDs is not meaningful, so a reorder alone must not trigger a
+// "changed" notification.
+func sameSlackUserIDSet(a, b []types.SlackUserID) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	seen := make(map[types.SlackUserID]int, len(a))
+	for _, id := range a {
+		seen[id]++
+	}
+	for _, id := range b {
+		seen[id]--
+		if seen[id] < 0 {
+			return false
+		}
+	}
+	return true
 }
 
 func statusName(entry *model.WorkspaceEntry, statusID types.StatusID) string {

--- a/pkg/usecase/ticket_test.go
+++ b/pkg/usecase/ticket_test.go
@@ -5,14 +5,40 @@ import (
 	"testing"
 
 	"github.com/m-mizutani/gt"
+	"github.com/m-mizutani/shepherd/pkg/domain/interfaces"
 	"github.com/m-mizutani/shepherd/pkg/domain/model"
 	"github.com/m-mizutani/shepherd/pkg/domain/model/config"
 	"github.com/m-mizutani/shepherd/pkg/domain/types"
 	"github.com/m-mizutani/shepherd/pkg/repository/memory"
+	slackService "github.com/m-mizutani/shepherd/pkg/service/slack"
 	"github.com/m-mizutani/shepherd/pkg/usecase"
 )
 
+type fakeTicketChangeNotifier struct {
+	calls []fakeTicketChangeCall
+}
+
+type fakeTicketChangeCall struct {
+	channelID string
+	threadTS  string
+	change    slackService.TicketChange
+}
+
+func (f *fakeTicketChangeNotifier) NotifyTicketChange(_ context.Context, channelID, threadTS string, change slackService.TicketChange) error {
+	f.calls = append(f.calls, fakeTicketChangeCall{
+		channelID: channelID,
+		threadTS:  threadTS,
+		change:    change,
+	})
+	return nil
+}
+
 func setupTicketUseCase(t *testing.T) (*usecase.TicketUseCase, *model.WorkspaceRegistry) {
+	uc, _, _, registry := setupTicketUseCaseFull(t, nil)
+	return uc, registry
+}
+
+func setupTicketUseCaseFull(t *testing.T, notifier usecase.TicketChangeNotifier) (*usecase.TicketUseCase, interfaces.Repository, *fakeTicketChangeNotifier, *model.WorkspaceRegistry) {
 	t.Helper()
 	repo := memory.New()
 	t.Cleanup(func() { _ = repo.Close() })
@@ -35,8 +61,14 @@ func setupTicketUseCase(t *testing.T) (*usecase.TicketUseCase, *model.WorkspaceR
 		SlackChannelID: "C111",
 	})
 
-	uc := usecase.NewTicketUseCase(repo, registry, nil)
-	return uc, registry
+	var fake *fakeTicketChangeNotifier
+	if notifier == nil {
+		fake = &fakeTicketChangeNotifier{}
+		notifier = fake
+	}
+
+	uc := usecase.NewTicketUseCase(repo, registry, notifier)
+	return uc, repo, fake, registry
 }
 
 func TestTicketUseCase_Create(t *testing.T) {
@@ -191,4 +223,103 @@ func TestTicketUseCase_Update_NoStatusChange_NoHistory(t *testing.T) {
 
 	histories := gt.R1(uc.ListHistory(ctx, "ws-test", ticket.ID)).NoError(t)
 	gt.A(t, histories).Length(1) // only the "created" entry
+}
+
+// seedSlackTicket creates a ticket and immediately attaches Slack
+// metadata to it via the repository so subsequent Update calls go
+// through the Slack notifier path. The metadata seed itself bypasses
+// the usecase to avoid a spurious notification on a freshly created
+// ticket that has no observable status / assignee transition yet.
+func seedSlackTicket(t *testing.T, uc *usecase.TicketUseCase, repo interfaces.Repository, assignees []types.SlackUserID) *model.Ticket {
+	t.Helper()
+	ctx := context.Background()
+	created := gt.R1(uc.Create(ctx, "ws-test", "Seeded", "desc", "", assignees, nil)).NoError(t)
+	got := gt.R1(repo.Ticket().Get(ctx, "ws-test", created.ID)).NoError(t)
+	got.SlackChannelID = "C111"
+	got.SlackThreadTS = "1700000000.000100"
+	updated := gt.R1(repo.Ticket().Update(ctx, "ws-test", got)).NoError(t)
+	return updated
+}
+
+func TestTicketUseCase_Update_StatusChange_NotifiesOnce(t *testing.T) {
+	uc, repo, notifier, _ := setupTicketUseCaseFull(t, nil)
+	ctx := context.Background()
+
+	ticket := seedSlackTicket(t, uc, repo, nil)
+
+	newStatus := types.StatusID("in-progress")
+	gt.R1(uc.Update(ctx, "ws-test", ticket.ID, nil, nil, &newStatus, nil, nil)).NoError(t)
+
+	gt.A(t, notifier.calls).Length(1)
+	call := notifier.calls[0]
+	gt.S(t, call.channelID).Equal("C111")
+	gt.S(t, call.threadTS).Equal("1700000000.000100")
+	gt.V(t, call.change.StatusChanged).Equal(true)
+	gt.V(t, call.change.AssigneeChanged).Equal(false)
+	gt.S(t, call.change.OldStatusName).Equal("Open")
+	gt.S(t, call.change.NewStatusName).Equal("In Progress")
+}
+
+func TestTicketUseCase_Update_AssigneeChange_NotifiesOnce(t *testing.T) {
+	uc, repo, notifier, _ := setupTicketUseCaseFull(t, nil)
+	ctx := context.Background()
+
+	ticket := seedSlackTicket(t, uc, repo, nil)
+
+	newAssignees := []types.SlackUserID{"U111", "U222"}
+	gt.R1(uc.Update(ctx, "ws-test", ticket.ID, nil, nil, nil, &newAssignees, nil)).NoError(t)
+
+	gt.A(t, notifier.calls).Length(1)
+	call := notifier.calls[0]
+	gt.V(t, call.change.StatusChanged).Equal(false)
+	gt.V(t, call.change.AssigneeChanged).Equal(true)
+	gt.A(t, call.change.OldAssigneeIDs).Length(0)
+	gt.A(t, call.change.NewAssigneeIDs).Length(2)
+	gt.S(t, call.change.NewAssigneeIDs[0]).Equal("U111")
+}
+
+func TestTicketUseCase_Update_StatusAndAssignee_NotifiesOnce(t *testing.T) {
+	uc, repo, notifier, _ := setupTicketUseCaseFull(t, nil)
+	ctx := context.Background()
+
+	ticket := seedSlackTicket(t, uc, repo, []types.SlackUserID{"U000"})
+
+	newStatus := types.StatusID("resolved")
+	newAssignees := []types.SlackUserID{"U999"}
+	gt.R1(uc.Update(ctx, "ws-test", ticket.ID, nil, nil, &newStatus, &newAssignees, nil)).NoError(t)
+
+	gt.A(t, notifier.calls).Length(1)
+	call := notifier.calls[0]
+	gt.V(t, call.change.StatusChanged).Equal(true)
+	gt.V(t, call.change.AssigneeChanged).Equal(true)
+	gt.S(t, call.change.NewStatusName).Equal("Resolved")
+	gt.A(t, call.change.OldAssigneeIDs).Length(1)
+	gt.S(t, call.change.OldAssigneeIDs[0]).Equal("U000")
+	gt.S(t, call.change.NewAssigneeIDs[0]).Equal("U999")
+}
+
+func TestTicketUseCase_Update_NoChange_NoNotify(t *testing.T) {
+	uc, repo, notifier, _ := setupTicketUseCaseFull(t, nil)
+	ctx := context.Background()
+
+	ticket := seedSlackTicket(t, uc, repo, []types.SlackUserID{"U000"})
+
+	// Title-only change must not fire the notifier.
+	newTitle := "Renamed"
+	gt.R1(uc.Update(ctx, "ws-test", ticket.ID, &newTitle, nil, nil, nil, nil)).NoError(t)
+
+	gt.A(t, notifier.calls).Length(0)
+}
+
+func TestTicketUseCase_Update_AssigneeReorder_NoNotify(t *testing.T) {
+	uc, repo, notifier, _ := setupTicketUseCaseFull(t, nil)
+	ctx := context.Background()
+
+	ticket := seedSlackTicket(t, uc, repo, []types.SlackUserID{"U001", "U002"})
+
+	// Same set, different order — assignee membership is unchanged.
+	reordered := []types.SlackUserID{"U002", "U001"}
+	gt.R1(uc.Update(ctx, "ws-test", ticket.ID, nil, nil, nil, &reordered, nil)).NoError(t)
+
+	gt.A(t, notifier.calls).Length(0)
 }

--- a/pkg/usecase/triage/usecase_test.go
+++ b/pkg/usecase/triage/usecase_test.go
@@ -379,6 +379,11 @@ func (f *fakeUserSlack) ReplyTicketCreated(_ context.Context, ch, ts string, seq
 	return nil
 }
 
+func (f *fakeUserSlack) PostThreadBlocks(_ context.Context, ch, ts string, _ []slackgo.Block) (string, error) {
+	_, _ = ch, ts
+	return "", nil
+}
+
 func (f *fakeUserSlack) GetUserInfo(_ context.Context, id string) (*slackService.UserInfo, error) {
 	return &slackService.UserInfo{ID: id, Name: id}, nil
 }

--- a/pkg/utils/i18n/en.go
+++ b/pkg/utils/i18n/en.go
@@ -5,6 +5,15 @@ var en = map[MsgKey]string{
 	MsgStatusChange:      "Status: *{old}* → *{new}*",
 	MsgStatusChangeLabel: "Status",
 
+	MsgAssigneeChange: "Assignee: {old} → {new}",
+	MsgUnassigned:     "(unassigned)",
+
+	MsgQuickActionsHeader:              "*Quick actions*",
+	MsgQuickActionsAssigneeLabel:       "Assignee",
+	MsgQuickActionsStatusLabel:         "Status",
+	MsgQuickActionsStatusPlaceholder:   "Select a status",
+	MsgQuickActionsAssigneePlaceholder: "Select assignees",
+
 	MsgTicketRefActive:    "🎫 <{url}|Ticket #{id}> — {title}",
 	MsgTicketRefInactive:  "<{url}|Ticket #{id}> — {title}",
 	MsgTicketRefDismissed: "~<{url}|Ticket #{id}> — {title}~",

--- a/pkg/utils/i18n/ja.go
+++ b/pkg/utils/i18n/ja.go
@@ -5,6 +5,15 @@ var ja = map[MsgKey]string{
 	MsgStatusChange:      "ステータス: *{old}* → *{new}*",
 	MsgStatusChangeLabel: "ステータス",
 
+	MsgAssigneeChange: "担当者: {old} → {new}",
+	MsgUnassigned:     "（未割当）",
+
+	MsgQuickActionsHeader:              "*クイック操作*",
+	MsgQuickActionsAssigneeLabel:       "担当者",
+	MsgQuickActionsStatusLabel:         "ステータス",
+	MsgQuickActionsStatusPlaceholder:   "ステータスを選択",
+	MsgQuickActionsAssigneePlaceholder: "担当者を選択",
+
 	MsgTicketRefActive:    "🎫 <{url}|チケット #{id}> — {title}",
 	MsgTicketRefInactive:  "<{url}|チケット #{id}> — {title}",
 	MsgTicketRefDismissed: "~<{url}|チケット #{id}> — {title}~",

--- a/pkg/utils/i18n/keys.go
+++ b/pkg/utils/i18n/keys.go
@@ -7,6 +7,24 @@ const (
 	MsgStatusChange      MsgKey = "status_change"
 	MsgStatusChangeLabel MsgKey = "status_change_label"
 
+	// Ticket change notification (context block) — emitted whenever a
+	// TicketUseCase.Update mutation flips the ticket's status or assignee
+	// regardless of which entry point (HTTP API, Slack quick-actions menu,
+	// future surfaces) drove the change. The two pieces are interpolated
+	// into a single context block so simultaneous status + assignee
+	// transitions render as one notification, not two.
+	MsgAssigneeChange MsgKey = "assignee_change"
+	MsgUnassigned     MsgKey = "unassigned"
+
+	// Slack empty-mention quick-actions menu — posted into the ticket
+	// thread when a user @-mentions the bot with no body. Lets the user
+	// switch the ticket's assignee or status without leaving Slack.
+	MsgQuickActionsHeader            MsgKey = "quick_actions_header"
+	MsgQuickActionsAssigneeLabel     MsgKey = "quick_actions_assignee_label"
+	MsgQuickActionsStatusLabel       MsgKey = "quick_actions_status_label"
+	MsgQuickActionsStatusPlaceholder MsgKey = "quick_actions_status_placeholder"
+	MsgQuickActionsAssigneePlaceholder MsgKey = "quick_actions_assignee_placeholder"
+
 	// Three rendering forms for the ticket reference line, applied at the
 	// top of every ticket-scoped Slack message. The form is chosen by the
 	// message's lifecycle state so a thread reader can tell at a glance


### PR DESCRIPTION
## Summary

- Empty Slack mention (`@shepherd` only, no body) now posts an inline Quick Actions menu into the ticket thread with a `multi_users_select` for assignees and a `static_select` for statuses; the LLM-reply path is preserved for non-empty mentions and is unaffected.
- Unified status / assignee change notifications: `StatusChangeNotifier` is replaced by `TicketChangeNotifier`. `TicketUseCase.Update` now detects status- and assignee-deltas in one pass and emits a single context-block notification per logical update, regardless of whether the change came from the HTTP API, the new quick-actions menu, or a future surface.
- New `QuickActionsUseCase` resolves the ticket from `channel_id` + `thread_ts` (the menu always lives as a thread reply), then funnels mutations through `TicketUseCase.Update` so the notification path is exercised exactly once per change.
- HTTP interactions handler accepts a `QuickActionsInteractionsUC` alongside the existing triage UC and dispatches the new `quick_actions_assignee_select` / `quick_actions_status_select` `block_actions` ids using the established ack-fast / dispatch-async pattern.
- New i18n keys (`MsgAssigneeChange`, `MsgUnassigned`, `MsgQuickActions*`) added to both `en.go` and `ja.go`. `docs/slack.md` updated with new sections describing the empty-mention menu and the unified change notifications.

## Test plan

- [x] `task generate` succeeds (Go + TypeScript code generation)
- [x] `task build` succeeds (frontend + Go binary)
- [x] `task test` is green across every package, including new unit tests:
  - `TicketUseCase.Update` differential cases: status only, assignee only, both, no-op, reorder-only
  - `BuildQuickActionsBlocks` preselects current assignees and status
  - `HandleAppMention` empty-mention branch posts Quick Actions and does NOT call the LLM (asserted with a failing mock)
  - `HandleAppMention` empty mention works even when LLM is unconfigured
  - `QuickActionsUseCase` updates the ticket and fires the notifier (status / assignee / clear-assignees / unmapped channel / unknown thread)
- [ ] Manual verification on a real Slack workspace (smoke test of the empty mention → menu → status / assignee change → context-block notification flow)