### PR TITLE
docs: clarify handleBlockActions co-arrival comment

### DIFF
--- a/pkg/controller/http/slack_interactions.go
+++ b/pkg/controller/http/slack_interactions.go
@@ -92,12 +92,15 @@ func slackInteractionsHandler(triageUC TriageInteractionsUC, quickUC QuickAction
 func handleBlockActions(ctx context.Context, w http.ResponseWriter, triageUC TriageInteractionsUC, quickUC QuickActionsInteractionsUC, cb *slackgo.InteractionCallback) {
 	logger := logging.From(ctx)
 
-	// Quick-actions selects (assignee / status) and triage buttons can in
-	// principle co-arrive in the same payload, though Slack's UI delivers
-	// at most one action per click. Iterate once, classify, and dispatch
-	// each match. Quick-actions resolve the underlying ticket from
-	// channel + thread_ts (the menu lives as a thread reply on the
-	// ticket's root message), so we forward those raw fields.
+	// A block_actions payload is always scoped to a single Slack message,
+	// and triage review messages and quick-actions menus are distinct
+	// messages — the two action families therefore never co-arrive in
+	// one payload. We classify the payload, branch on whichever family
+	// is present, and have the triage path return early so the
+	// quick-actions tail only runs when no triage action was seen.
+	// Quick-actions resolve the underlying ticket from channel +
+	// thread_ts (the menu lives as a thread reply on the ticket's root
+	// message), so we forward those raw fields.
 	channelID := cb.Channel.ID
 	threadTS := cb.Message.ThreadTimestamp
 	if threadTS == "" {


### PR DESCRIPTION
## Summary

Follow-up to PR #34. The review comment from gemini-code-assist on `pkg/controller/http/slack_interactions.go` correctly flagged a mismatch between the comment and the implementation: the comment claimed triage and quick-actions `block_actions` could in principle co-arrive in one payload, but the code returns early on a triage hit and never reaches the quick-actions tail.

In practice the two action families target distinct Slack messages (the triage review message vs. the quick-actions menu), so a single `block_actions` payload can never carry both. The early-return is therefore correct; the comment was simply misleading.

This PR rewords the comment to reflect that reality and reaffirm why the early-return is the right shape. No behavior change.

## Test plan

- [x] `go vet ./...` clean
- [x] `go test ./pkg/controller/http/...` green