### PR TITLE
refactor: rename triage plan action to probe and drop propose_ prefix

### DIFF
--- a/pkg/domain/model/triage.go
+++ b/pkg/domain/model/triage.go
@@ -6,19 +6,18 @@ import (
 )
 
 // TriagePlan is the decoded LLM response for a single planning turn. The LLM
-// chooses exactly one of propose_investigate / propose_ask / propose_complete,
-// and the corresponding payload field (Investigate / Ask / Complete) is set
-// while the others remain nil.
+// chooses exactly one of probe / ask / complete, and the corresponding
+// payload field (Probe / Ask / Complete) is set while the others remain nil.
 //
 // The plan itself is not persisted; the canonical record of past plans lives
 // in the gollem agent history (session "{wsID}/{ticketID}/plan"). Use
 // LoadLatestTriagePlan to recover the most recent plan from that history.
 type TriagePlan struct {
-	Kind        types.PlanKind `json:"kind"`
-	Message     string         `json:"message"` // Reporter-facing short status update; required for every plan.
-	Investigate *Investigate   `json:"investigate,omitempty"`
-	Ask         *Ask           `json:"ask,omitempty"`
-	Complete    *Complete      `json:"complete,omitempty"`
+	Kind     types.PlanKind `json:"kind"`
+	Message  string         `json:"message"` // Reporter-facing short status update; required for every plan.
+	Probe    *Probe         `json:"probe,omitempty"`
+	Ask      *Ask           `json:"ask,omitempty"`
+	Complete *Complete      `json:"complete,omitempty"`
 }
 
 // Validate ensures Kind matches the populated payload and that Message is set.
@@ -30,19 +29,19 @@ func (p *TriagePlan) Validate() error {
 		return goerr.New("triage plan message is empty")
 	}
 	switch p.Kind {
-	case types.PlanInvestigate:
-		if p.Investigate == nil {
-			return goerr.New("investigate payload missing", goerr.V("kind", p.Kind))
+	case types.PlanProbe:
+		if p.Probe == nil {
+			return goerr.New("probe payload missing", goerr.V("kind", p.Kind))
 		}
 		if p.Ask != nil || p.Complete != nil {
-			return goerr.New("only investigate payload should be set", goerr.V("kind", p.Kind))
+			return goerr.New("only probe payload should be set", goerr.V("kind", p.Kind))
 		}
-		return p.Investigate.Validate()
+		return p.Probe.Validate()
 	case types.PlanAsk:
 		if p.Ask == nil {
 			return goerr.New("ask payload missing", goerr.V("kind", p.Kind))
 		}
-		if p.Investigate != nil || p.Complete != nil {
+		if p.Probe != nil || p.Complete != nil {
 			return goerr.New("only ask payload should be set", goerr.V("kind", p.Kind))
 		}
 		return p.Ask.Validate()
@@ -50,7 +49,7 @@ func (p *TriagePlan) Validate() error {
 		if p.Complete == nil {
 			return goerr.New("complete payload missing", goerr.V("kind", p.Kind))
 		}
-		if p.Investigate != nil || p.Ask != nil {
+		if p.Probe != nil || p.Ask != nil {
 			return goerr.New("only complete payload should be set", goerr.V("kind", p.Kind))
 		}
 		return p.Complete.Validate()
@@ -59,17 +58,17 @@ func (p *TriagePlan) Validate() error {
 	}
 }
 
-// Investigate launches one or more child investigation subtasks in parallel.
-type Investigate struct {
+// Probe launches one or more child investigation subtasks in parallel.
+type Probe struct {
 	Subtasks []Subtask `json:"subtasks"`
 }
 
-func (i *Investigate) Validate() error {
-	if len(i.Subtasks) == 0 {
-		return goerr.New("investigate must have at least one subtask")
+func (p *Probe) Validate() error {
+	if len(p.Subtasks) == 0 {
+		return goerr.New("probe must have at least one subtask")
 	}
-	seen := make(map[types.SubtaskID]struct{}, len(i.Subtasks))
-	for idx, st := range i.Subtasks {
+	seen := make(map[types.SubtaskID]struct{}, len(p.Subtasks))
+	for idx, st := range p.Subtasks {
 		if err := st.Validate(); err != nil {
 			return goerr.Wrap(err, "invalid subtask", goerr.V("index", idx))
 		}

--- a/pkg/domain/model/triage_test.go
+++ b/pkg/domain/model/triage_test.go
@@ -9,13 +9,13 @@ import (
 	"github.com/m-mizutani/shepherd/pkg/domain/types"
 )
 
-func validInvestigatePlan() *model.TriagePlan {
+func validProbePlan() *model.TriagePlan {
 	uid := types.SlackUserID("U1")
 	_ = uid
 	return &model.TriagePlan{
-		Kind:    types.PlanInvestigate,
-		Message: "調査を開始します",
-		Investigate: &model.Investigate{
+		Kind:    types.PlanProbe,
+		Message: "Starting investigation",
+		Probe: &model.Probe{
 			Subtasks: []model.Subtask{
 				{
 					ID:                 "st1",
@@ -31,16 +31,16 @@ func validInvestigatePlan() *model.TriagePlan {
 func validAskPlan() *model.TriagePlan {
 	return &model.TriagePlan{
 		Kind:    types.PlanAsk,
-		Message: "確認させてください",
+		Message: "Please clarify a few points",
 		Ask: &model.Ask{
-			Title: "詳細確認",
+			Title: "Details",
 			Questions: []model.Question{
 				{
 					ID:    "q1",
-					Label: "影響範囲は？",
+					Label: "What is the scope of impact?",
 					Choices: []model.Choice{
-						{ID: "c1", Label: "本番"},
-						{ID: "c2", Label: "ステージング"},
+						{ID: "c1", Label: "Production"},
+						{ID: "c2", Label: "Staging"},
 					},
 				},
 			},
@@ -63,8 +63,8 @@ func validCompletePlan() *model.TriagePlan {
 }
 
 func TestTriagePlanValidate_Valid(t *testing.T) {
-	t.Run("investigate", func(t *testing.T) {
-		gt.NoError(t, validInvestigatePlan().Validate())
+	t.Run("probe", func(t *testing.T) {
+		gt.NoError(t, validProbePlan().Validate())
 	})
 	t.Run("ask", func(t *testing.T) {
 		gt.NoError(t, validAskPlan().Validate())
@@ -80,28 +80,28 @@ func TestTriagePlanValidate_NilOrEmpty(t *testing.T) {
 		gt.Error(t, p.Validate())
 	})
 	t.Run("empty message", func(t *testing.T) {
-		p := validInvestigatePlan()
+		p := validProbePlan()
 		p.Message = ""
 		err := p.Validate()
 		gt.Error(t, err)
 		gt.S(t, err.Error()).Contains("message")
 	})
 	t.Run("unknown kind", func(t *testing.T) {
-		p := validInvestigatePlan()
+		p := validProbePlan()
 		p.Kind = types.PlanKind("bogus")
 		gt.Error(t, p.Validate())
 	})
 }
 
 func TestTriagePlanValidate_PayloadMismatch(t *testing.T) {
-	t.Run("investigate kind missing payload", func(t *testing.T) {
-		p := validInvestigatePlan()
-		p.Investigate = nil
+	t.Run("probe kind missing payload", func(t *testing.T) {
+		p := validProbePlan()
+		p.Probe = nil
 		gt.Error(t, p.Validate())
 	})
-	t.Run("ask kind with extra investigate payload", func(t *testing.T) {
+	t.Run("ask kind with extra probe payload", func(t *testing.T) {
 		p := validAskPlan()
-		p.Investigate = validInvestigatePlan().Investigate
+		p.Probe = validProbePlan().Probe
 		gt.Error(t, p.Validate())
 	})
 	t.Run("complete kind missing payload", func(t *testing.T) {
@@ -111,18 +111,18 @@ func TestTriagePlanValidate_PayloadMismatch(t *testing.T) {
 	})
 }
 
-func TestInvestigateValidate(t *testing.T) {
+func TestProbeValidate(t *testing.T) {
 	t.Run("empty subtasks", func(t *testing.T) {
-		gt.Error(t, (&model.Investigate{}).Validate())
+		gt.Error(t, (&model.Probe{}).Validate())
 	})
 	t.Run("invalid subtask propagates", func(t *testing.T) {
-		inv := &model.Investigate{Subtasks: []model.Subtask{{ID: "", Request: "x", AcceptanceCriteria: []string{"y"}}}}
-		gt.Error(t, inv.Validate())
+		pr := &model.Probe{Subtasks: []model.Subtask{{ID: "", Request: "x", AcceptanceCriteria: []string{"y"}}}}
+		gt.Error(t, pr.Validate())
 	})
 	t.Run("duplicate subtask id", func(t *testing.T) {
 		st := model.Subtask{ID: "a", Request: "r", AcceptanceCriteria: []string{"c"}}
-		inv := &model.Investigate{Subtasks: []model.Subtask{st, st}}
-		err := inv.Validate()
+		pr := &model.Probe{Subtasks: []model.Subtask{st, st}}
+		err := pr.Validate()
 		gt.Error(t, err)
 		gt.S(t, err.Error()).Contains("duplicate")
 	})

--- a/pkg/domain/types/triage.go
+++ b/pkg/domain/types/triage.go
@@ -18,12 +18,12 @@ type ChoiceID string
 func (id ChoiceID) String() string { return string(id) }
 
 // PlanKind discriminates which action the LLM proposed for the current
-// iteration. Exactly one of TriagePlan.Investigate / Ask / Complete must be
+// iteration. Exactly one of TriagePlan.Probe / Ask / Complete must be
 // non-nil based on this Kind.
 type PlanKind string
 
 const (
-	PlanInvestigate PlanKind = "investigate"
-	PlanAsk         PlanKind = "ask"
-	PlanComplete    PlanKind = "complete"
+	PlanProbe    PlanKind = "probe"
+	PlanAsk      PlanKind = "ask"
+	PlanComplete PlanKind = "complete"
 )

--- a/pkg/usecase/prompt/prompt_test.go
+++ b/pkg/usecase/prompt/prompt_test.go
@@ -66,9 +66,9 @@ func TestRenderTriagePlan_FullInput(t *testing.T) {
 	gt.NoError(t, err)
 
 	for _, want := range []string{
-		"propose_investigate",
-		"propose_ask",
-		"propose_complete",
+		"`probe`",
+		"`ask`",
+		"`complete`",
 		"Sign-in broken on Safari",
 		"Users on Safari 17",
 		"<@U123>",
@@ -258,7 +258,7 @@ func TestRenderTriagePlan_NoToolsFallback(t *testing.T) {
 	got, err := prompt.RenderTriagePlan(prompt.TriagePlanInput{Title: "x"})
 	gt.NoError(t, err)
 	gt.S(t, got).Contains("No investigation tools are enabled for this workspace")
-	gt.S(t, got).Contains("Do not call `propose_investigate`")
+	gt.S(t, got).Contains("Do not choose `probe`")
 }
 
 func TestRenderTriagePlan_ProviderWithEmptyDescriptionStillListsTools(t *testing.T) {

--- a/pkg/usecase/prompt/triage_plan.md
+++ b/pkg/usecase/prompt/triage_plan.md
@@ -1,10 +1,10 @@
-You are the planner for the ticket triage agent in Shepherd. Your job is to look at the ticket context and any prior turn results, then decide what to do **next** by calling exactly one of the following tools:
+You are the planner for the ticket triage agent in Shepherd. Your job is to look at the ticket context and any prior turn results, then decide what to do **next** by setting the response `kind` to exactly one of the following actions:
 
-- `propose_investigate` — schedule one or more parallel investigation subtasks executed by child agents.
-- `propose_ask` — present a Slack form with structured questions to the reporter when information is missing that only they can provide.
-- `propose_complete` — finish triage with a hand-off summary and an assignee decision.
+- `probe` — schedule one or more parallel investigation subtasks executed by child agents.
+- `ask` — present a Slack form with structured questions to the reporter when information is missing that only they can provide.
+- `complete` — finish triage with a hand-off summary and an assignee decision.
 
-You **must** call exactly one of these tools per turn. Always include the `message` argument: a short (1-2 sentence) reporter-facing status update describing your current direction.
+You **must** pick exactly one of these actions per turn and populate the matching payload. Always include the `message` field: a short (1-2 sentence) reporter-facing status update describing your current direction.
 
 ## Ticket context
 
@@ -22,7 +22,7 @@ You **must** call exactly one of these tools per turn. Always include the `messa
 ## Available investigation tools
 
 {{- if .AvailableTools }}
-The following providers are enabled for this workspace. When you call `propose_investigate`, set each subtask's `allowed_tools` to the **exact tool names** listed under the relevant provider — names not in this list are silently dropped, and the child agent then runs with zero tools.
+The following providers are enabled for this workspace. When you choose `probe`, set each subtask's `allowed_tools` to the **exact tool names** listed under the relevant provider — names not in this list are silently dropped, and the child agent then runs with zero tools.
 {{- range .AvailableTools }}
 
 ### {{ .ID }}
@@ -39,31 +39,31 @@ Tools you may put in `allowed_tools`:
 
 {{- else }}
 
-No investigation tools are enabled for this workspace. Do not call `propose_investigate`; choose `propose_ask` or `propose_complete` instead.
+No investigation tools are enabled for this workspace. Do not choose `probe`; pick `ask` or `complete` instead.
 {{- end }}
 
 ## Choosing an action
 
-- Prefer `propose_investigate` first when at least one tool listed above is relevant and meaningful information can be discovered without bothering the reporter.
-- Choose `propose_ask` only when the missing pieces cannot be derived from investigation and must come from the reporter. Ask multiple independent questions in one form whenever possible. If two questions depend on each other, defer the dependent one to a later iteration.
-- Choose `propose_complete` only when you have enough to hand the ticket off. Prefer fewer turns over many.
+- Prefer `probe` first when at least one tool listed above is relevant and meaningful information can be discovered without bothering the reporter.
+- Choose `ask` only when the missing pieces cannot be derived from investigation and must come from the reporter. Ask multiple independent questions in one form whenever possible. If two questions depend on each other, defer the dependent one to a later iteration.
+- Choose `complete` only when you have enough to hand the ticket off. Prefer fewer turns over many.
 
-## Subtask quality (`propose_investigate`)
+## Subtask quality (`probe`)
 
-When you build subtasks for `propose_investigate`:
+When you build subtasks for `probe`:
 
 - `request` must be a single imperative-mood instruction (e.g. "Collect related Slack posts in the last 48h", "Identify the affected service from the description").
 - `acceptance_criteria` must contain 3 to 5 observable conditions. Each item should describe a property of the output a third party could check (e.g. "Returns at least 3 messages or explicitly states 'no related messages'", "Includes channel name, timestamp, and excerpt for each item"). Avoid vague language like "sufficient information".
 - `allowed_tools` must use only tool names listed under "Available investigation tools" above.
 
-## Question quality (`propose_ask`)
+## Question quality (`ask`)
 
 - Each question must include 3 to 6 predefined `choices`. The Slack form automatically pairs every question with a free-text "other" input, so do **not** add an "other" choice yourself.
 - Even questions that look open-ended (e.g. "What was the reproduction step?") should be split into a categorical choice + free text. For example, ask "When did the issue happen?" with choices like "On creation / On edit / On delete / On listing / Other" instead of a raw text question.
 - `id` for each question must be a stable, unique identifier within this Ask. It will be used as a Slack `block_id` to match the reporter's submission back to the question definition.
 - Combine independent questions in one form. Do not combine questions whose answer would change the next question.
 
-## Completion (`propose_complete`)
+## Completion (`complete`)
 
 - `assignee.user_ids` carries the assignment: an array of real Slack user id strings (e.g. `["U123ABC"]` or `["U123ABC", "U456DEF"]`) when you can confidently pick owners, or an empty array (or omit the field) to leave the ticket unassigned.
 - Add a second or third owner only when ownership genuinely spans people — e.g. the work straddles two teams, or the on-call rotation pairs primary + backup. Prefer the smallest correct set; do not pad the list "just in case".
@@ -73,9 +73,9 @@ When you build subtasks for `propose_investigate`:
 - Use `key_findings` (bullets), `next_steps` (bullets), `similar_tickets` (ticket ids), and `answer_summary` (label → reporter answer summary) to give the assignee actionable context.
 {{- if .AutoFillFields }}
 
-### Auto-fill custom fields (required on `propose_complete`)
+### Auto-fill custom fields (required on `complete`)
 
-When you call `propose_complete`, the `suggested_fields` object **must** include an entry for each of the following fields. The map key is the field `id`; the value's shape depends on the field `type` listed below. Pick from the listed option ids verbatim — do **not** invent new ids and do **not** translate or relabel them.
+When you choose `complete`, the `suggested_fields` object **must** include an entry for each of the following fields. The map key is the field `id`; the value's shape depends on the field `type` listed below. Pick from the listed option ids verbatim — do **not** invent new ids and do **not** translate or relabel them.
 
 {{- range .AutoFillFields }}
 
@@ -115,10 +115,10 @@ If you genuinely cannot determine a value for a non-required auto-fill field, om
 
 ## Rules
 
-- Always call exactly one `propose_*` tool per turn.
-- Never call any other tool here — investigation tools belong to child agents launched by `propose_investigate`.
+- Always pick exactly one action (`probe` / `ask` / `complete`) per turn and populate only that payload.
+- Never call any tool here — investigation tools belong to child agents launched by `probe`.
 - Do not invent ids; reuse stable ids that you can refer back to in later turns.
-- Do not omit the `message` argument; it is required.
+- Do not omit the `message` field; it is required.
 {{- if .UserGuidance }}
 
 ---

--- a/pkg/usecase/triage/executor.go
+++ b/pkg/usecase/triage/executor.go
@@ -229,13 +229,13 @@ func (e *PlanExecutor) run(ctx context.Context, workspaceID types.WorkspaceID, t
 		}
 
 		switch plan.Kind {
-		case types.PlanInvestigate:
-			progress, perr := newProgressMessage(ctx, e.slack, ticket.SlackChannelID, ticket.SlackThreadTS, e.ticketRef(ticket), plan.Message, plan.Investigate.Subtasks)
+		case types.PlanProbe:
+			progress, perr := newProgressMessage(ctx, e.slack, ticket.SlackChannelID, ticket.SlackThreadTS, e.ticketRef(ticket), plan.Message, plan.Probe.Subtasks)
 			if perr != nil {
 				return goerr.Wrap(perr, "post progress message")
 			}
-			if err := e.runInvestigate(ctx, ticket, plan, progress); err != nil {
-				return goerr.Wrap(err, "investigate")
+			if err := e.runProbe(ctx, ticket, plan, progress); err != nil {
+				return goerr.Wrap(err, "probe")
 			}
 			// Loop back: ask the LLM what to do next.
 			continue
@@ -293,7 +293,7 @@ func (e *PlanExecutor) reportFailure(ctx context.Context, ticket *model.Ticket, 
 // postAsk renders and posts the question form. There is no Slack-side state
 // to remember beyond what the message itself encodes (block_id = question
 // id; action.value = ticket id) — re-deriving the questions on submit comes
-// from the agent history's latest propose_ask tool call.
+// from the agent history's latest ask plan.
 func (e *PlanExecutor) postAsk(ctx context.Context, ticket *model.Ticket, plan *model.TriagePlan) error {
 	if plan.Ask == nil {
 		return goerr.New("plan kind ask without payload")

--- a/pkg/usecase/triage/executor_test.go
+++ b/pkg/usecase/triage/executor_test.go
@@ -94,7 +94,7 @@ func TestExecutorRun_IterationCapExceeded_FinalizesAsAborted(t *testing.T) {
 	// sees count >= cap and short-circuits to abort. cap is 5 per newRig.
 	h := &gollem.History{Version: gollem.HistoryVersion}
 	for range 5 {
-		h.Messages = append(h.Messages, mustAssistantPlanMessage(t, investigatePlanJSON))
+		h.Messages = append(h.Messages, mustAssistantPlanMessage(t, probePlanJSON))
 		// Pair each plan turn with a user-role message so IsWaitingUserSubmit
 		// stays false (no trailing ask).
 		h.Messages = append(h.Messages, mustUserTextMessage(t, "result"))
@@ -358,7 +358,7 @@ func TestExecutorRun_NoToolsConfigured_FallbackInSystemPrompt(t *testing.T) {
 	gt.NoError(t, exec2.RunForTest(context.Background(), tWS, ticket.ID))
 
 	gt.S(t, captured).Contains("No investigation tools are enabled for this workspace")
-	gt.S(t, captured).Contains("Do not call `propose_investigate`")
+	gt.S(t, captured).Contains("Do not choose `probe`")
 }
 
 // TestExecutorRun_LLMProposesComplete_DefaultRequiresReview_PostsReviewWithoutFinalize

--- a/pkg/usecase/triage/history_test.go
+++ b/pkg/usecase/triage/history_test.go
@@ -58,10 +58,10 @@ func mustUserTextMessage(t *testing.T, text string) gollem.Message {
 	}
 }
 
-const investigatePlanJSON = `{
-  "kind": "investigate",
+const probePlanJSON = `{
+  "kind": "probe",
   "message": "Investigating now",
-  "investigate": {
+  "probe": {
     "subtasks": [
       {
         "id": "st1",
@@ -144,19 +144,19 @@ func TestLoadLatestTriagePlan_Empty(t *testing.T) {
 	gt.Nil(t, plan)
 }
 
-func TestLoadLatestTriagePlan_Investigate(t *testing.T) {
+func TestLoadLatestTriagePlan_Probe(t *testing.T) {
 	repo := newFakeHistory()
 	ctx := context.Background()
 	h := &gollem.History{Version: gollem.HistoryVersion}
-	h.Messages = append(h.Messages, mustAssistantPlanMessage(t, investigatePlanJSON))
+	h.Messages = append(h.Messages, mustAssistantPlanMessage(t, probePlanJSON))
 	gt.NoError(t, repo.Save(ctx, "ws/tk/plan", h))
 
 	plan := gt.R1(triage.LoadLatestTriagePlanForTest(ctx, repo, "ws", "tk")).NoError(t)
 	gt.NotNil(t, plan)
-	gt.Equal(t, plan.Kind, types.PlanInvestigate)
-	gt.NotNil(t, plan.Investigate)
-	gt.N(t, len(plan.Investigate.Subtasks)).Equal(1)
-	gt.S(t, plan.Investigate.Subtasks[0].Request).Equal("Collect related Slack posts")
+	gt.Equal(t, plan.Kind, types.PlanProbe)
+	gt.NotNil(t, plan.Probe)
+	gt.N(t, len(plan.Probe.Subtasks)).Equal(1)
+	gt.S(t, plan.Probe.Subtasks[0].Request).Equal("Collect related Slack posts")
 	gt.S(t, plan.Message).Equal("Investigating now")
 }
 
@@ -179,7 +179,7 @@ func TestLoadLatestTriagePlan_PicksLatest(t *testing.T) {
 	ctx := context.Background()
 	h := &gollem.History{Version: gollem.HistoryVersion}
 	h.Messages = append(h.Messages,
-		mustAssistantPlanMessage(t, investigatePlanJSON),
+		mustAssistantPlanMessage(t, probePlanJSON),
 		mustUserTextMessage(t, "Investigate result: ..."),
 		mustAssistantPlanMessage(t, askPlanJSON),
 	)
@@ -219,7 +219,7 @@ func TestIsWaitingUserSubmit(t *testing.T) {
 
 	t.Run("investigate trailing", func(t *testing.T) {
 		h := &gollem.History{Version: gollem.HistoryVersion}
-		h.Messages = append(h.Messages, mustAssistantPlanMessage(t, investigatePlanJSON))
+		h.Messages = append(h.Messages, mustAssistantPlanMessage(t, probePlanJSON))
 		gt.NoError(t, repo.Save(ctx, "ws/tk-inv/plan", h))
 		ok := gt.R1(triage.IsWaitingUserSubmitForTest(ctx, repo, "ws", "tk-inv")).NoError(t)
 		gt.False(t, ok)
@@ -238,7 +238,7 @@ func TestCountPlannerTurns(t *testing.T) {
 	t.Run("multiple plans", func(t *testing.T) {
 		h := &gollem.History{Version: gollem.HistoryVersion}
 		h.Messages = append(h.Messages,
-			mustAssistantPlanMessage(t, investigatePlanJSON),
+			mustAssistantPlanMessage(t, probePlanJSON),
 			mustUserTextMessage(t, "Investigate result"),
 			mustAssistantPlanMessage(t, askPlanJSON),
 			mustUserTextMessage(t, "Q1=A1"),

--- a/pkg/usecase/triage/llm.go
+++ b/pkg/usecase/triage/llm.go
@@ -70,7 +70,7 @@ func (e *PlanExecutor) llmPlan(ctx context.Context, ticket *model.Ticket) (*mode
 	)
 
 	// Non-empty kickoff text: Gemini's GenerateContent rejects empty parts.
-	kickoff := gollem.Text("Decide and return a TriagePlan choosing exactly one of investigate / ask / complete based on the ticket and any prior context above.")
+	kickoff := gollem.Text("Decide and return a TriagePlan choosing exactly one of probe / ask / complete based on the ticket and any prior context above.")
 
 	cap := e.cfg.PlanRetryCap
 	for attempt := 0; attempt <= cap; attempt++ {

--- a/pkg/usecase/triage/probe.go
+++ b/pkg/usecase/triage/probe.go
@@ -16,17 +16,17 @@ import (
 	"github.com/m-mizutani/shepherd/pkg/utils/msg"
 )
 
-// runInvestigate executes the planner's Investigate decision: spin up a
-// child gollem agent per subtask in parallel, surface progress through the
-// per-subtask Slack context blocks, and feed the aggregated summaries back
-// to the planner via the plan-level history.
+// runProbe executes the planner's Probe decision: spin up a child gollem
+// agent per subtask in parallel, surface progress through the per-subtask
+// Slack context blocks, and feed the aggregated summaries back to the
+// planner via the plan-level history.
 //
 // Each subtask gets its own gollem session ("{ws}/{ticket}/sub/{subtaskID}")
 // so its tool-call traces stay isolated from the planner agent.
-func (e *PlanExecutor) runInvestigate(ctx context.Context, ticket *model.Ticket, plan *model.TriagePlan, progress *progressMessage) error {
-	inv := plan.Investigate
-	if inv == nil {
-		return goerr.New("runInvestigate called without Investigate payload")
+func (e *PlanExecutor) runProbe(ctx context.Context, ticket *model.Ticket, plan *model.TriagePlan, progress *progressMessage) error {
+	pr := plan.Probe
+	if pr == nil {
+		return goerr.New("runProbe called without Probe payload")
 	}
 
 	allTools, err := e.catalog.For(ctx, ticket.WorkspaceID)
@@ -37,13 +37,13 @@ func (e *PlanExecutor) runInvestigate(ctx context.Context, ticket *model.Ticket,
 
 	var (
 		mu        sync.Mutex
-		summaries = make(map[types.SubtaskID]string, len(inv.Subtasks))
-		failures  = make(map[types.SubtaskID]string, len(inv.Subtasks))
+		summaries = make(map[types.SubtaskID]string, len(pr.Subtasks))
+		failures  = make(map[types.SubtaskID]string, len(pr.Subtasks))
 	)
 
-	fns := make([]func(context.Context) error, 0, len(inv.Subtasks))
-	for i := range inv.Subtasks {
-		st := inv.Subtasks[i]
+	fns := make([]func(context.Context) error, 0, len(pr.Subtasks))
+	for i := range pr.Subtasks {
+		st := pr.Subtasks[i]
 		fns = append(fns, func(ctx context.Context) error {
 			return e.runSubtask(ctx, ticket, st, allTools, progress, &mu, summaries, failures)
 		})
@@ -55,13 +55,13 @@ func (e *PlanExecutor) runInvestigate(ctx context.Context, ticket *model.Ticket,
 		// partial results to the planner — losing one subtask should not
 		// kill the iteration — but the error is surfaced via errutil so it
 		// reaches logs and Sentry.
-		errutil.Handle(ctx, goerr.Wrap(err, "investigate subtasks"))
+		errutil.Handle(ctx, goerr.Wrap(err, "probe subtasks"))
 	}
 
 	// Feed aggregated results back as a user message so the planner sees them.
-	contextMsg := formatInvestigationContext(inv.Subtasks, summaries, failures)
+	contextMsg := formatProbeContext(pr.Subtasks, summaries, failures)
 	if err := appendUserMessage(ctx, e.historyRepo, ticket.WorkspaceID, ticket.ID, contextMsg); err != nil {
-		return goerr.Wrap(err, "append investigate result to plan history")
+		return goerr.Wrap(err, "append probe result to plan history")
 	}
 	return nil
 }
@@ -123,9 +123,9 @@ func (e *PlanExecutor) runSubtask(ctx context.Context, ticket *model.Ticket, st 
 	return nil
 }
 
-func formatInvestigationContext(subtasks []model.Subtask, summaries, failures map[types.SubtaskID]string) string {
+func formatProbeContext(subtasks []model.Subtask, summaries, failures map[types.SubtaskID]string) string {
 	var b strings.Builder
-	b.WriteString("Investigate result:\n")
+	b.WriteString("Probe result:\n")
 	for _, st := range subtasks {
 		b.WriteString("\n- Subtask ")
 		b.WriteString(string(st.ID))

--- a/pkg/usecase/triage/schema.go
+++ b/pkg/usecase/triage/schema.go
@@ -8,7 +8,7 @@ import (
 
 // triagePlanSchema is the JSON shape the LLM must return on every planner
 // turn. It mirrors model.TriagePlan: a discriminated union keyed on `kind`
-// where exactly one of `investigate` / `ask` / `complete` is populated.
+// where exactly one of `probe` / `ask` / `complete` is populated.
 //
 // autoFill is the subset of the workspace schema's custom fields whose
 // AutoFill flag is set; the function uses it to constrain the
@@ -20,14 +20,14 @@ import (
 func triagePlanSchema(autoFill []domainConfig.FieldDefinition) *gollem.Parameter {
 	return &gollem.Parameter{
 		Title:       "TriagePlan",
-		Description: "Decision the planner makes for one triage turn. Set kind to exactly one of investigate / ask / complete and populate the matching payload (the other two payload fields must be omitted).",
+		Description: "Decision the planner makes for one triage turn. Set kind to exactly one of probe / ask / complete and populate the matching payload (the other two payload fields must be omitted).",
 		Type:        gollem.TypeObject,
 		Properties: map[string]*gollem.Parameter{
 			"kind": {
 				Type:        gollem.TypeString,
 				Description: "Which action this plan represents. Must match the populated payload.",
 				Required:    true,
-				Enum:        []string{"investigate", "ask", "complete"},
+				Enum:        []string{"probe", "ask", "complete"},
 			},
 			"message": {
 				Type:        gollem.TypeString,
@@ -35,17 +35,17 @@ func triagePlanSchema(autoFill []domainConfig.FieldDefinition) *gollem.Parameter
 				Required:    true,
 				MinLength:   intPtr(1),
 			},
-			"investigate": investigateSchema(),
-			"ask":         askSchema(),
-			"complete":    completeSchema(autoFill),
+			"probe":    probeSchema(),
+			"ask":      askSchema(),
+			"complete": completeSchema(autoFill),
 		},
 	}
 }
 
-func investigateSchema() *gollem.Parameter {
+func probeSchema() *gollem.Parameter {
 	return &gollem.Parameter{
 		Type:        gollem.TypeObject,
-		Description: "Populated when kind=investigate. Schedules subtasks to run in parallel.",
+		Description: "Populated when kind=probe. Schedules subtasks to run in parallel.",
 		Properties: map[string]*gollem.Parameter{
 			"subtasks": {
 				Type:        gollem.TypeArray,

--- a/pkg/usecase/triage/usecase_test.go
+++ b/pkg/usecase/triage/usecase_test.go
@@ -208,9 +208,9 @@ func TestHandleSubmit_LatestPlanNotAsk_Invalidates(t *testing.T) {
 	uc, _, repo, hist, slack := newRig(t, nil)
 	ticket := mustCreateTicket(t, repo, false)
 
-	// Seed plan history with a propose_investigate (not an Ask).
+	// Seed plan history with a probe plan (not an Ask).
 	h := &gollem.History{Version: gollem.HistoryVersion}
-	h.Messages = append(h.Messages, mustAssistantPlanMessage(t, investigatePlanJSON))
+	h.Messages = append(h.Messages, mustAssistantPlanMessage(t, probePlanJSON))
 	gt.NoError(t, hist.Save(context.Background(), triage.PlanSessionIDForTest(tWS, ticket.ID), h))
 
 	gt.NoError(t, uc.HandleSubmit(context.Background(), triage.Submission{
@@ -226,7 +226,7 @@ func TestHandleSubmit_NotWaiting_Invalidates(t *testing.T) {
 	uc, _, repo, hist, slack := newRig(t, nil)
 	ticket := mustCreateTicket(t, repo, false)
 
-	// Seed: propose_ask followed by an already-recorded user response. That
+	// Seed: ask plan followed by an already-recorded user response. That
 	// is the "answers already submitted" condition — the form is stale.
 	h := &gollem.History{Version: gollem.HistoryVersion}
 	h.Messages = append(h.Messages,
@@ -395,7 +395,7 @@ func (f *fakeUserSlack) ListUsers(_ context.Context) ([]*slackService.UserInfo, 
 // state machine end-to-end through the public entry points
 // (HandleNewMessage and HandleSubmit), with no hand-rolled intermediate
 // state. The LLM mock is sequenced so the first planner turn returns
-// propose_ask and the second (resumed by Submit) returns propose_complete.
+// ask plan and the second (resumed by Submit) returns complete plan.
 //
 // Assertions are layered at every observable transition: agent history
 // shape, Slack call ordering, and finally the persisted ticket fields.
@@ -507,7 +507,7 @@ func TestLifecycle_TicketCreate_Ask_Submit_Complete(t *testing.T) {
 	gt.A(t, userSlack.ticketCreated).Length(1)
 	gt.S(t, userSlack.ticketCreated[0].channelID).Equal(channel)
 
-	// First planner turn ran and produced propose_ask in plan history.
+	// First planner turn ran and produced an ask plan in plan history.
 	plan := gt.R1(triage.LoadLatestTriagePlanForTest(ctx, hist, wsID, ticket.ID)).NoError(t)
 	gt.NotNil(t, plan)
 	gt.Equal(t, plan.Kind, types.PlanAsk)
@@ -539,7 +539,7 @@ func TestLifecycle_TicketCreate_Ask_Submit_Complete(t *testing.T) {
 	gt.S(t, triageSlack.updates[0].messageTS).Equal(askMessageTS)
 
 	// History: the formatted answers landed as a user-role text message
-	// after the propose_ask tool call.
+	// after the ask plan turn.
 	hh := gt.R1(hist.Load(ctx, triage.PlanSessionIDForTest(wsID, ticket.ID))).NoError(t)
 	gt.NotNil(t, hh)
 	var userTexts []string
@@ -578,7 +578,7 @@ func TestLifecycle_TicketCreate_Ask_Submit_Complete(t *testing.T) {
 	// LLM was driven exactly twice — turn 1 (ask) + turn 2 (complete).
 	gt.N(t, int(atomic.LoadInt32(&llmCalls))).Equal(2)
 
-	// Latest plan in history is now propose_complete, confirming the
+	// Latest plan in history is now a complete plan, confirming the
 	// resumed turn was persisted.
 	finalPlan := gt.R1(triage.LoadLatestTriagePlanForTest(ctx, hist, wsID, ticket.ID)).NoError(t)
 	gt.Equal(t, finalPlan.Kind, types.PlanComplete)


### PR DESCRIPTION
## Summary

- Rename the planner action previously known as `investigate` to `probe`, dropping the `propose_` prefix from prompt-side names.
- The change spans the LLM-facing JSON schema (`kind` enum + payload key), the planner system prompt (`triage_plan.md`), the Go domain types (`PlanInvestigate` → `PlanProbe`, `model.Investigate` → `model.Probe`), the executor (`runInvestigate` → `runProbe`, `formatInvestigationContext` → `formatProbeContext`), and the test fixtures.
- Out of scope (intentionally unchanged): the user-facing "Re-investigate" Slack button and its persistent `triage_review_reinvestigate` ActionID — those are end-user copy / Slack interaction ids whose names should not churn.

## Notes

- Existing `TriageHistory` documents that hold the old `kind: "investigate"` shape will not be readable by the new code. In-flight triages may need to be re-run; closed tickets are unaffected. No migration command is added.
- All Go tests pass via `zenv go test ./...` (including the Firestore-backed repository suite).

## Test plan

- [ ] `zenv go test ./...` passes locally (verified)
- [ ] Existing planner / triage flows are exercised in a dev workspace and produce the new structured output (`kind: "probe"` etc.)